### PR TITLE
Native ExLlamaV3 packs: n-gram embedding tables, mul1 experts, padded dense geometry (Qwen3.8-Flash-Next)

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -4,6 +4,9 @@
   the EXL3 trellis/MCG format and the compiled kernels this plugin drives.
 - **[vLLM](https://github.com/vllm-project/vllm)** — the serving engine and
   the plugin/quantization interfaces this package registers into.
+- **[turboderp/Qwen3.8-Flash-Next-exl3](https://huggingface.co/turboderp/Qwen3.8-Flash-Next-exl3)**
+  — thank you for the native EXL3 pack used to validate this release's
+  native-pack support (n-gram embedding, mul1 experts, padded dense geometry).
 - **[MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks)**
   (MIT-licensed) — idea and benchmark credits, routed-expert serving path, and
   Fat GEMM CUDA kernels (`csrc/exl3_fat_gemm.cu` and `csrc/exl3_fat_gemm.cuh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Native fused-MoE decode-row cap measured on GB10 (K2: 8 rows, K3/K4: 1) ships as an opt-in
+  (`VLLM_EXL3_NATIVE_MOE_MEASURED_CAP=1`, or `VLLM_EXL3_NATIVE_MOE_MAX_ROWS=<n>`); the default keeps
+  the dispatch contract of up to 8 rows. Receipt: `tools/receipts/ab_moe_gb10.json`.
 - Add `Exl3EmbeddingMethod` for row-wise n-gram embedding tables
   (`ngram_embedding`), decoded through the compiled
   `exllamav3_ext.ngram_dequant` kernel or a pure-torch fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Unreleased
 
+- Add `Exl3EmbeddingMethod` for row-wise n-gram embedding tables
+  (`ngram_embedding`), decoded through the compiled
+  `exllamav3_ext.ngram_dequant` kernel or a pure-torch fallback
+  (`VLLM_EXL3_NGRAM_KERNEL=ext|torch`).
+- Add the `ngram_embedding` config spec (`bits`, `num_shards`,
+  `rows_per_shard`, `num_heads`, `modules`) and its checkpoint layout
+  (`shard_<i>.trellis`, `head_bias`, `head_offsets`, `head_vocab_sizes`,
+  `layer_multipliers`); tensor parallel size 1 only.
+- Extend `get_quant_method` with branches for `ParallelLMHead` and
+  `VocabParallelEmbedding`, so EXL3 `lm_head` and n-gram tables resolve
+  once a model passes `quant_config=` through to those layers.
+- Accept tuple and `None` shard-id spans in the dense linear weight
+  loader, for fused modules with more than one contiguous shard and for
+  full-tensor (non-sharded) loads.
+- Generalize `_check_moe_codebook_markers` to validate `mul1` markers
+  for routed experts alongside `mcg`.
+- Add `_exl3_routed_experts_loader`, a per-expert `load_weights` path for
+  routed-experts layers that mirrors vLLM's own checkpoint-name
+  resolution for one-tensor-per-expert EXL3 checkpoints.
+- Pad dense EXL3 linear geometry to multiples of 128 so trellis tiles
+  never spill past the real matrix dimension.
+- Thread per-tensor codebook flags (mcg/mul1) through the fused
+  `exl3_moe` launch arguments.
+- Register the EXL3 custom ops so they trace opaquely under
+  `torch.compile(fullgraph=True)` instead of breaking graph capture.
+- Restore the CUDA-graph-safe fat-expert-sync guard (skip the device
+  sync entirely when the row count cannot produce a fat expert) and the
+  MTP/draft-expert quant-method delegate (prefer MXFP4, matching DSV4's
+  own fp4 draft experts, before falling back to the non-routed delegate).
+- Add `tools/patch_vllm_qwen4_exp` (vLLM quant_config plumbing for
+  `Qwen4ExpForConditionalGeneration`), `tools/exl3_pack_tools`
+  (pack scanning, config rewriting, and
+  `regenerate_safetensors_index.py`), and `tools/verify_native_pack`
+  (four pre-boot GPU correctness gates).
+- Add attribution notices for ExLlamaV3's n-gram embedding codec and for
+  vLLM's routed-experts loader / custom-op registration; thank
+  turboderp for the Qwen3.8-Flash-Next-exl3 pack used to validate this
+  release.
+
 - Extend the native fused MoE ABI with local intermediate width (1024 or 2048)
   and optional input-clipped SwiGLU. Clamp the gate before SiLU and the up
   projection symmetrically; zero keeps plain SwiGLU. Preserve K2/K3/K4 support.

--- a/NOTICE
+++ b/NOTICE
@@ -9,5 +9,7 @@ This product contains and derives from MIT-licensed software by other authors:
     pointer tables, and Fat GEMM CUDA kernels (Copyright (c) 2026 Mia's AI Lab)
   - ExLlamaV3 by Turboderp ([@turboderp](https://github.com/turboderp), [turboderp-org/exllamav3](https://github.com/turboderp-org/exllamav3)): EXL3 trellis format,
     MCG codebook, and low-bit quantization math (Copyright (c) 2025 Turboderp)
+  - ExLlamaV3's row-wise n-gram embedding codec (ngram_codec.py / ngram_dequant),
+    reimplemented as a torch fallback in src/vllm_exl3/exl3.py (Copyright (c) 2025 Turboderp)
 Their copyright and permission notices are reproduced in THIRD_PARTY_NOTICES.md,
 which must be retained with any redistribution.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ TTFT):
 | Mode | Decode | TTFT (128 tok) | Mean acceptance | Ready | On device | KV cache |
 |---|---|---|---|---|---|---|
 | No draft | 27.2-28.0 tok/s | 0.185 s | -- | ~13 min | 78.6 GiB | 385,570 tokens |
-| MTP k=1 | 33.8-36.4 tok/s | 0.185 s | 1.86 of 2 | ~13 min | 78.6 GiB | 385,570 tokens (no draft) |
+| MTP k=1 | 33.8-36.4 tok/s | 0.199 s | 1.86 of 2 | ~13 min | 78.6 GiB | 275,636 tokens |
 | MTP k=2 | 37.3-41.3 tok/s | 0.201 s | 2.54 of 3 | ~13 min | 78.6 GiB | 275,636 tokens (MTP) |
 
 Recipe: https://github.com/vcruz305/Qwen3.8-Flash-Next-EXL3-DGX-Spark-recipe

--- a/README.md
+++ b/README.md
@@ -134,6 +134,43 @@ This prevents long prompt prefill from starving parallel decode steps and stalli
 |---|---|---|
 | `Glm5Next` (GLM-5.3-Flash) | serving-proven | GLM-5.3-Flash EXL3 K2 / K2K3-mix |
 | `DeepseekV4` (DeepSeek-V4-Flash) | serving-proven on stock vLLM 0.28.0 (text, DSpark draft) and on the vLLM nightly vision class (text + images + DSpark draft, 64k context, tool calling); three small serving-side patches live in the recipe | DSV4-Flash-Vision EXL3 MixedK |
+| `Qwen4ExpForConditionalGeneration` (Qwen3.8-Flash-Next) | serving-proven, native ExLlamaV3 pack (fractional-bit mul1 experts, padded dense linears, row-wise n-gram embedding table); three small vLLM patches in `tools/patch_vllm_qwen4_exp/` | [turboderp/Qwen3.8-Flash-Next-exl3](https://huggingface.co/turboderp/Qwen3.8-Flash-Next-exl3), revision `3.05bpw_h5_ng5` |
+
+### Native ExLlamaV3 packs
+
+Beyond packs produced by this project's own conversion path, the plugin also
+serves packs quantized directly by turboderp's ExLlamaV3 tooling ("native"
+packs), which can assign a fractional average bit width (e.g. 3.05 bpw) by
+choosing bits per tensor rather than one width for the whole model. Support
+for this covers:
+
+- the `mul1` codebook (alongside `mcg`), selected per tensor via the packed
+  marker rather than declared once for the whole model;
+- per-tensor K for dense linears and `lm_head` through `non_routed_exl3`;
+- matrices padded to a multiple of 128 so trellis tiles never spill past
+  the real dimension;
+- row-wise n-gram embedding tables (`ngram_embedding`) kept packed instead
+  of expanded to BF16 -- 30.4 GiB on device instead of 102 GB.
+
+A native pack's `config.json` was not written for this plugin, so
+`tools/exl3_pack_tools/` rewrites it (see that directory's README), and
+`model.safetensors.index.json` must list every `*.safetensors` file the pack
+actually ships or vLLM silently skips tensors --
+`tools/exl3_pack_tools/regenerate_safetensors_index.py` rebuilds it from the
+files on disk. `Qwen4ExpForConditionalGeneration` also needs the three vLLM
+patches in `tools/patch_vllm_qwen4_exp/` so vLLM's own model code passes
+`quant_config` through to `lm_head` and the n-gram table at all.
+
+**Preliminary numbers** (2026-09-07, one DGX Spark GB10, 128 GB, 32768
+context, `--gpu-memory-utilization 0.80`, one request, decode excluding
+TTFT):
+
+| Mode | Decode | TTFT (128 tok) | Mean acceptance | Ready | On device | KV cache |
+|---|---|---|---|---|---|---|
+| No draft | 27.2-28.0 tok/s | 0.185 s | -- | ~13 min | 78.6 GiB | 385,570 tokens |
+| MTP k=1 | 33.8-36.4 tok/s | 0.185 s | 1.86 of 2 | ~13 min | 78.6 GiB | 385,570 tokens (no draft) |
+
+Recipe: https://github.com/vcruz305/Qwen3.8-Flash-Next-EXL3-DGX-Spark-recipe
 
 ## Config contract
 
@@ -190,7 +227,33 @@ wrong by construction:
   loads `.trellis/.suh/.svh` plus one `.mcg` or `.mul1` marker; a stale
   BF16 `.weight` for an EXL3 shard is shape-checked and discarded, so a pack
   may overlay EXL3 tensors on top of shards that still carry the BF16 copy.
-  `lm_head` is not covered yet.
+  `lm_head` is covered too: give it its own entry under
+  `non_routed_exl3.layers` (or match it via the short form's `modules`) once
+  the model passes `quant_config=` through to its `ParallelLMHead`. Not every
+  model does this by default -- `Qwen4ExpForConditionalGeneration` needs the
+  vLLM patches in `tools/patch_vllm_qwen4_exp/` first.
+- `ngram_embedding` *(optional)* -- a row-wise n-gram embedding table kept in
+  its packed ExLlamaV3 format instead of expanded to BF16 (e.g. the PLE table
+  in `Qwen4ExpForConditionalGeneration`):
+
+  ```json
+  "ngram_embedding": {
+    "bits": 5,
+    "num_shards": 128,
+    "rows_per_shard": 2500012,
+    "num_heads": 16,
+    "modules": ["ngram_embedding"]
+  }
+  ```
+
+  `modules` matches by prefix suffix, same as `non_routed_exl3`'s short form.
+  The checkpoint stores, per shard, `shard_<i>.trellis` (int16,
+  `[rows_per_shard, 1 + 160*bits/16]`), plus one `head_bias` (fp16,
+  `[num_heads, 160]`), `head_offsets` and `head_vocab_sizes` (int64,
+  `[num_heads]`), and `layer_multipliers` (int64). Tensor parallel size 1
+  only. The dequant kernel is chosen with `VLLM_EXL3_NGRAM_KERNEL=ext`
+  (default, the compiled `exllamav3_ext` kernel) or `=torch` (a pure-PyTorch
+  fallback, used by the CPU-only unit tests and as a correctness cross-check).
 
 ## Install
 
@@ -200,8 +263,11 @@ one-shot installs — see
 and the recipe repos below. Or install straight from a GitHub release:
 
 ```bash
-pip install https://github.com/vcruz305/vllm-exl3/releases/download/v0.2.0/vllm_exl3-0.2.0-py3-none-any.whl
+pip install https://github.com/vcruz305/vllm-exl3/releases/download/v0.3.1/vllm_exl3-0.3.1-cp312-cp312-linux_aarch64.whl
 ```
+
+Check the [releases page](https://github.com/vcruz305/vllm-exl3/releases) for
+the current platform tag; wheels are built per Python/arch combination.
 
 The old `glm53_exl3_plugin` import path still works via a deprecated shim
 and will be removed in a future release.
@@ -267,6 +333,10 @@ Apache-2.0. Redistribution must retain the [NOTICE](NOTICE) file — see
   the nightly vision class. Upstreaming those patches and the `FusedMoE` compat
   layer for other architectures is next; GLM-5.3 remains fork-only until the
   architecture exists upstream.
-- Dense EXL3 for `lm_head` (`ParallelLMHead`) and TP>1 with `bf16_shards`.
+- **Dense EXL3 for `lm_head` (`ParallelLMHead`): done in this release**, via
+  `non_routed_exl3` (plus the vLLM plumbing patches for
+  `Qwen4ExpForConditionalGeneration`). Padded dense geometry and n-gram
+  embedding tables are tensor-parallel-1 only; TP>1 with `bf16_shards`
+  remains open.
 - Fat-expert prefill acceleration (sorted/batched expert dispatch) for extreme
   contexts.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ TTFT):
 |---|---|---|---|---|---|---|
 | No draft | 27.2-28.0 tok/s | 0.185 s | -- | ~13 min | 78.6 GiB | 385,570 tokens |
 | MTP k=1 | 33.8-36.4 tok/s | 0.185 s | 1.86 of 2 | ~13 min | 78.6 GiB | 385,570 tokens (no draft) |
+| MTP k=2 | 37.3-41.3 tok/s | 0.201 s | 2.54 of 3 | ~13 min | 78.6 GiB | 275,636 tokens (MTP) |
 
 Recipe: https://github.com/vcruz305/Qwen3.8-Flash-Next-EXL3-DGX-Spark-recipe
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -63,6 +63,15 @@ The CUDA sources in `csrc/` build against ExLlamaV3's extension headers, includi
 `ptx.cuh`, and the GEMV and batched kernels reuse its kernel body. The EXL3 trellis format, the MCG
 codebook and the quantization method itself are ExLlamaV3's work.
 
+### ExLlamaV3 n-gram embedding codec
+
+`ngram_dequant_rows_torch` and `ngram_mul1_codebook` in `src/vllm_exl3/exl3.py` reimplement, as a
+pure-Python/CPU fallback, the row layout and mul1 codebook arithmetic of ExLlamaV3's
+`exllamav3/modules/quant/exl3_lib/ngram_codec.py` and its `ngram_dequant` CUDA kernel. The serving
+path itself calls ExLlamaV3's own `ngram_dequant` kernel through `exllamav3_ext`; the torch
+reimplementation exists for correctness cross-checking and for environments without the compiled
+kernel.
+
 ```
 MIT License
 
@@ -86,3 +95,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+
+
+---
+
+## vLLM
+
+Author: the vLLM project ([vllm-project/vllm](https://github.com/vllm-project/vllm)).
+
+`_exl3_routed_experts_loader` in `src/vllm_exl3/exl3.py` mirrors the checkpoint-name resolution of
+vLLM's `RoutedExperts.load_weights`, adapted to load one EXL3 tensor per expert instead of taking
+vLLM's fused (3-D) branch. This plugin's custom ops are also registered through vLLM's
+`direct_register_custom_op`. Apache-2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vllm-exl3"
-version = "0.3.1"
+version = "0.4.0"
 description = "EXL3 (ExLlamaV3 trellis/MCG) quantization plugin for vLLM fork runtimes"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/vllm_exl3/exl3.py
+++ b/src/vllm_exl3/exl3.py
@@ -783,14 +783,46 @@ def _native_moe_dimensions_supported(
         return False
     hidden_meta = int(getattr(layer, "_exl3_hidden_size", x2d.shape[1]))
     inter_meta = int(getattr(layer, "_exl3_intermediate_local", 2048))
-    return (
-        1 <= int(x2d.shape[0]) <= 8
+    rows = int(x2d.shape[0])
+    bits = int(getattr(layer, "_exl3_k", getattr(layer, "_exl3_bits", -1)))
+    if not (
+        rows >= 1
         and int(x2d.shape[1]) == hidden_meta == 4096
         and inter_meta in (1024, 2048)
-        and int(getattr(layer, "_exl3_k", getattr(layer, "_exl3_bits", -1)))
-        in (2, 3, 4)
+        and bits in (2, 3, 4)
         and len(inners) > 0
-    )
+    ):
+        return False
+    return rows <= _native_moe_max_rows(bits)
+
+
+# Measured on one GB10 (sm_121) against exllamav3 exl3_moe in the same process, identical
+# experts and routing, 288 experts, top-8, hidden 4096, intermediate 2048. Speedup of
+# p2b_fused_moe over exl3_moe, median of 50 launches with fresh routing per launch:
+#
+#   K=2:  m=1 1.69x   m=2 1.21x   m=4 1.23x   m=8 1.06x
+#   K=3:  m=1 1.27x   m=2 0.95x   m=4 0.96x   m=8 0.82x
+#   K=4:  m=1 1.28x   m=2 1.00x   m=4 1.01x   m=8 0.89x
+#
+# The native ABI takes one row per launch, so cost grows linearly with rows while exl3_moe
+# batches them in a single launch. Dispatch is therefore capped per bit width at the largest
+# row count that still measured a win. Receipt: tools/receipts/ab_moe_gb10.json.
+_NATIVE_MOE_MAX_ROWS = {2: 8, 3: 1, 4: 1}
+
+
+def _native_moe_max_rows(bits: int) -> int:
+    """Largest decode row count where the native kernel measured faster than exl3_moe."""
+    override = os.environ.get("VLLM_EXL3_NATIVE_MOE_MAX_ROWS")
+    if override:
+        try:
+            value = int(override)
+        except ValueError:
+            logger.warning(
+                "Ignoring non-integer VLLM_EXL3_NATIVE_MOE_MAX_ROWS=%r", override
+            )
+        else:
+            return max(0, value)
+    return _NATIVE_MOE_MAX_ROWS.get(int(bits), 1)
 
 
 def _apply_native_fused_moe(
@@ -1177,11 +1209,11 @@ def apply_exl3_fused_moe(
             )
         return out
 
+    fat = counts > FAT_EXPERT_THRESHOLD
     # counts[e] cannot exceed the row count, so with no more rows than the
     # threshold no expert can be fat. Testing that Python-side first keeps the
     # device sync below off the decode path, where graph capture forbids it.
     fat_possible = tokens > FAT_EXPERT_THRESHOLD
-    fat = counts > FAT_EXPERT_THRESHOLD
     fat_route = torch.zeros_like(local, dtype=torch.bool)
     if fat_possible and bool(fat.any().item()):
         safe_local = local.clamp(min=0, max=max(n_exp - 1, 0))
@@ -1417,10 +1449,6 @@ class Exl3Config(QuantizationConfig):
         if self.bits not in (2, 3, 4, 5, 6):
             raise ValueError(f"unsupported EXL3 bits={self.bits}")
 
-    def get_name(self) -> str:
-        return "exl3"
-
-    _LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
 
     def _mtp_expert_method(self, layer, prefix):
         """Quant method for draft/MTP experts, which stay in the base format.
@@ -1451,6 +1479,11 @@ class Exl3Config(QuantizationConfig):
             if method is not None:
                 return method, "non_routed"
         return None, "none"
+
+    def get_name(self) -> str:
+        return "exl3"
+
+    _LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
 
     def bits_for_prefix(self, prefix: str) -> int:
         """Per-layer K: `layer_bits` entry for this layer, else the base K."""

--- a/src/vllm_exl3/exl3.py
+++ b/src/vllm_exl3/exl3.py
@@ -10,16 +10,17 @@ work, Copyright (c) 2025 Turboderp, MIT. See THIRD_PARTY_NOTICES.md.
 """
 
 # SPDX-License-Identifier: Apache-2.0
-# EXL3/MCG trellis quantization for GLM-5.3-Flash routed experts.
+# EXL3 trellis quantization for routed experts, dense linears
+# (non_routed_exl3), lm_head (ParallelLMHead) and row-wise n-gram embedding
+# tables (ngram_embedding).
 #
-# Checkpoint ABI used by this pack:
-#   quant_method=exl3, codebook=mcg, scope=glm53_routed_experts_only
-#   per expert matrix: trellis (int16) + suh/svh (fp16) + mcg (int32 marker)
+# Codebooks are mcg or mul1. Per-tensor K comes from layer_bits and
+# non_routed_exl3.layers; matrices are padded to multiples of 128.
+# Non-routed tensors without a spec stay native (UnquantizedLinearMethod).
 #
-# Non-routed tensors stay native (UnquantizedLinearMethod). Experts never
-# expand to a persistent BF16 weight; LinearEXL3 / exllamav3_ext runs the
-# trellis GEMM. TP=2 shards gate/up column-wise and down row-wise; the MoE
-# runner all-reduces the combined output.
+# Experts never expand to a persistent BF16 weight; LinearEXL3 /
+# exllamav3_ext runs the trellis GEMM. TP=2 shards gate/up column-wise and
+# down row-wise; the MoE runner all-reduces the combined output.
 
 from __future__ import annotations
 
@@ -51,7 +52,10 @@ try:
         LinearMethodBase,
         UnquantizedLinearMethod,
     )
-    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+    from vllm.model_executor.layers.quantization.base_config import (
+        QuantizationConfig,
+        QuantizeMethodBase,
+    )
     from vllm.model_executor.layers.quantization import register_quantization_config
     from vllm.model_executor.utils import set_weight_attrs
     _VLLM_AVAILABLE = True
@@ -79,6 +83,9 @@ except ImportError:
         pass
 
     class QuantizationConfig:  # type: ignore[no-redef]
+        pass
+
+    class QuantizeMethodBase:  # type: ignore[no-redef]
         pass
 
     def register_quantization_config(name: str):  # type: ignore[no-redef]
@@ -1170,9 +1177,13 @@ def apply_exl3_fused_moe(
             )
         return out
 
+    # counts[e] cannot exceed the row count, so with no more rows than the
+    # threshold no expert can be fat. Testing that Python-side first keeps the
+    # device sync below off the decode path, where graph capture forbids it.
+    fat_possible = tokens > FAT_EXPERT_THRESHOLD
     fat = counts > FAT_EXPERT_THRESHOLD
     fat_route = torch.zeros_like(local, dtype=torch.bool)
-    if bool(fat.any().item()):
+    if fat_possible and bool(fat.any().item()):
         safe_local = local.clamp(min=0, max=max(n_exp - 1, 0))
         fat_route = (local < n_exp) & fat.index_select(0, safe_local)
 
@@ -1220,12 +1231,7 @@ def apply_exl3_fused_moe(
         ptrs["down_trellis"],
         ptrs["down_suh"],
         ptrs["down_svh"],
-        True,
-        False,
-        True,
-        False,
-        True,
-        False,
+        *getattr(layer, "_exl3_codebook_flags", (True, False, True, False, True, False)),
         float(limit) if (limit is not None and limit > 0) else 0.0,
     )
     if n_active_host is not None:
@@ -1233,7 +1239,7 @@ def apply_exl3_fused_moe(
     else:
         fn(*args)
 
-    if bool(fat.any().item()):
+    if fat_possible and bool(fat.any().item()):
         fat_order = local.argsort()
         apply_exl3_batched_fat(
             xh,
@@ -1318,6 +1324,11 @@ def _suffix_from_mapped_name(weight_name: str) -> str:
     raise ValueError(f"not an EXL3 packed name: {weight_name}")
 
 
+def _exl3_pad128(n: int) -> int:
+    """EXL3 stores matrices padded to multiples of 128 on both dims."""
+    return (int(n) + 127) // 128 * 128
+
+
 def _prefix_has_suffix(prefix: str, suffix: str) -> bool:
     """Module-path suffix match: "self_attn.o_proj" matches
     "model.layers.3.self_attn.o_proj" but not "...cross_attn.o_proj_x"."""
@@ -1385,6 +1396,19 @@ class Exl3Config(QuantizationConfig):
             raise ValueError(
                 f"unsupported non_routed_exl3 codebook={nr_codebook!r}; must be 'mcg' or 'mul1'"
             )
+        # Optional row-wise trellis embedding table in exllamav3's n-gram format
+        # (Qwen3.8-Flash-Next PLE), e.g. {"bits": 5, "num_shards": 128,
+        # "rows_per_shard": 2500012, "num_heads": 16, "modules": ["ngram_embedding"]}.
+        raw_ngram = kwargs.pop("ngram_embedding", None) or {}
+        self.ngram_embedding: dict[str, Any] = dict(raw_ngram) if raw_ngram else {}
+        if self.ngram_embedding:
+            for key in ("bits", "num_shards", "rows_per_shard", "num_heads"):
+                if int(self.ngram_embedding.get(key, 0) or 0) <= 0:
+                    raise ValueError(f"ngram_embedding.{key} must be a positive integer")
+            if int(self.ngram_embedding["bits"]) not in range(1, 9):
+                raise ValueError(
+                    f"unsupported ngram_embedding bits={self.ngram_embedding['bits']}"
+                )
         self.raw_config = dict(kwargs)
         if self.codebook not in ("mcg", "mul1"):
             raise ValueError(
@@ -1397,6 +1421,36 @@ class Exl3Config(QuantizationConfig):
         return "exl3"
 
     _LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
+
+    def _mtp_expert_method(self, layer, prefix):
+        """Quant method for draft/MTP experts, which stay in the base format.
+
+        These are the model's own experts, fp4 for DSV4: packed weights with
+        E8M0 block scales, which vLLM loads by looking up w13_weight_scale. The
+        non-routed delegate describes fp8 block quantization for the attention
+        and dense layers and creates w13_weight_scale_inv instead, so it cannot
+        serve these. Prefer MXFP4, whose MoE method creates the expected names,
+        and keep the non-routed delegate as the fallback for packs that are not
+        fp4. Returns (method, description).
+        """
+        if str(getattr(self, "mtp_expert_dtype", "fp4")) == "fp4":
+            try:
+                from vllm.model_executor.layers.quantization.mxfp4 import (
+                    Mxfp4Config,
+                )
+
+                method = Mxfp4Config().get_quant_method(layer, prefix)
+                if method is not None:
+                    return method, "mxfp4"
+            except Exception as exc:  # pragma: no cover - depends on vLLM build
+                if os.environ.get("VLLM_EXL3_LOG_MOE_ROUTING"):
+                    print(f"[exl3-routing] mxfp4 delegate unusable: {exc}", flush=True)
+        delegate = self._non_routed_delegate()
+        if delegate is not None:
+            method = delegate.get_quant_method(layer, prefix)
+            if method is not None:
+                return method, "non_routed"
+        return None, "none"
 
     def bits_for_prefix(self, prefix: str) -> int:
         """Per-layer K: `layer_bits` entry for this layer, else the base K."""
@@ -1516,6 +1570,17 @@ class Exl3Config(QuantizationConfig):
             return "exl3"
         return None
 
+    def _ngram_embedding_spec(self, prefix: str) -> dict[str, Any] | None:
+        """The n-gram table spec if ``prefix`` names one of its modules, else None."""
+        spec = getattr(self, "ngram_embedding", None) or {}
+        if not spec:
+            return None
+        modules = list(spec.get("modules") or ["ngram_embedding"])
+        for m in modules:
+            if prefix == m or prefix.endswith("." + m):
+                return spec
+        return None
+
     def get_quant_method(self, layer: torch.nn.Module, prefix: str):
         from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 
@@ -1526,12 +1591,21 @@ class Exl3Config(QuantizationConfig):
             if getattr(self, "mtp_experts", "exl3") == "source":
                 _start = getattr(self, "mtp_experts_start_layer", None)
                 _lm = re.search(r"layers\.(\d+)\.", prefix)
-                if _start is not None and _lm and int(_lm.group(1)) >= int(_start):
-                    d = self._non_routed_delegate()
-                    if d is not None:
-                        dm = d.get_quant_method(layer, prefix)
-                        if dm is not None:
-                            return dm
+                _by_index = bool(
+                    _start is not None and _lm and int(_lm.group(1)) >= int(_start)
+                )
+                if _by_index:
+                    dm, how = self._mtp_expert_method(layer, prefix)
+                    if dm is not None:
+                        if os.environ.get("VLLM_EXL3_LOG_MOE_ROUTING"):
+                            print(
+                                f"[exl3-routing] MoE {prefix} -> source via {how} "
+                                f"(by_index={_by_index})",
+                                flush=True,
+                            )
+                        return dm
+            if os.environ.get("VLLM_EXL3_LOG_MOE_ROUTING"):
+                print(f"[exl3-routing] MoE {prefix} -> exl3", flush=True)
             return Exl3MoEMethod(
                 layer.moe_config, self, bits=self.bits_for_prefix(prefix)
             )
@@ -1539,6 +1613,7 @@ class Exl3Config(QuantizationConfig):
             # Check if this LinearBase should use non_routed_exl3
             if self._matches_non_routed_exl3(prefix):
                 bits = self._bits_for_non_routed(prefix)
+                layer._exl3_prefix = prefix
                 return Exl3LinearMethod(self, bits=bits)
             if getattr(self, "non_routed_dtype_policy", "") == "bf16_as_stored":
                 return UnquantizedLinearMethod()
@@ -1548,6 +1623,28 @@ class Exl3Config(QuantizationConfig):
                 if m is not None:
                     return m
             return UnquantizedLinearMethod()
+        # Embedding-family layers. vLLM only consults quant_config for these when
+        # the model passes it (qwen4_exp needs quant_config= on ParallelLMHead and
+        # on the PLE table). lm_head is an ordinary trellis linear; the PLE n-gram
+        # table is the row-wise exllamav3 format served by Exl3EmbeddingMethod.
+        try:
+            from vllm.model_executor.layers.vocab_parallel_embedding import (
+                ParallelLMHead,
+                VocabParallelEmbedding,
+            )
+        except ImportError:  # pragma: no cover
+            return None
+        if isinstance(layer, ParallelLMHead):
+            if self._matches_non_routed_exl3(prefix):
+                layer._exl3_prefix = prefix
+                return Exl3LinearMethod(self, bits=self._bits_for_non_routed(prefix))
+            return None
+        if isinstance(layer, VocabParallelEmbedding):
+            spec = self._ngram_embedding_spec(prefix)
+            if spec is not None:
+                layer._exl3_prefix = prefix
+                return Exl3EmbeddingMethod(self, spec)
+            return None
         return None
 
     def _non_routed_delegate(self):
@@ -1584,6 +1681,80 @@ class Exl3Config(QuantizationConfig):
                         f"quant_method={name!r} config={nrq!r}"
                     ) from exc
         return self._nr_delegate_cached
+
+
+# Mirrors the checkpoint-name resolution of vLLM's RoutedExperts.load_weights
+# (vllm-project/vllm, Apache-2.0); see THIRD_PARTY_NOTICES.md.
+def _exl3_routed_experts_loader(layer: torch.nn.Module):
+    """Per-expert ``load_weights`` for a RoutedExperts layer holding EXL3 tensors.
+
+    Mirrors vLLM's ``RoutedExperts.load_weights`` name resolution but never takes its
+    fused (3-D) branch: an EXL3 checkpoint always stores one tensor per expert.
+    """
+
+    def load_weights(weights):
+        try:
+            mapping = layer.get_expert_mapping(include_fused=True)
+        except TypeError:
+            mapping = layer.get_expert_mapping()
+        layer_name = str(getattr(layer, "layer_name", ""))
+        for expert_name, loaded_weight in weights:
+            qual_name = f"{layer_name}.{expert_name}" if layer_name else expert_name
+            for param_name, weight_name, expert_id, shard_id in mapping:
+                if weight_name not in qual_name:
+                    continue
+                full_name = qual_name.replace(weight_name, param_name)
+                local_name = full_name.removeprefix(f"{layer_name}.")
+                param = getattr(layer, local_name, None)
+                if param is None:
+                    if local_name.endswith(("w13_bias", "w2_bias")):
+                        break
+                    raise AttributeError(
+                        f"EXL3 routed experts {layer_name!r} has no parameter "
+                        f"{local_name!r} for checkpoint weight {qual_name!r}"
+                    )
+                ok = param.weight_loader(
+                    param=param,
+                    loaded_weight=loaded_weight,
+                    weight_name=full_name,
+                    shard_id=shard_id,
+                    expert_id=expert_id,
+                    return_success=True,
+                )
+                if ok:
+                    yield local_name
+                break
+
+    return load_weights
+
+
+def _moe_marker_or_none(marker: torch.Tensor):
+    """A codebook marker tensor if it was loaded (non-zero), else None."""
+    return marker if int(marker.reshape(-1)[0].item()) != 0 else None
+
+
+def _check_moe_codebook_markers(mcg: torch.Tensor, mul1: torch.Tensor, what: str) -> None:
+    """Every expert tensor carries exactly one codebook marker with the known value."""
+    mcg_v = mcg.reshape(-1)
+    mul1_v = mul1.reshape(-1)
+    mcg_set = mcg_v != 0
+    mul1_set = mul1_v != 0
+    if bool((mcg_set & mul1_set).any()):
+        raise RuntimeError(f"EXL3 {what}: an expert tensor has both mcg and mul1 markers")
+    if bool((~mcg_set & ~mul1_set).any()):
+        raise RuntimeError(
+            f"EXL3 {what}: an expert tensor has no codebook marker (mcg or mul1 never loaded)"
+        )
+    if bool((mcg_v[mcg_set] != MCG_MARKER_SIGNED_INT32).any()):
+        raise RuntimeError(
+            f"EXL3 {what}: mcg marker is not the MCG int32 {MCG_MARKER_SIGNED_INT32}; "
+            "packed ABI mismatch"
+        )
+    if bool((mul1_v[mul1_set] != MUL1_MARKER_SIGNED_INT32).any()):
+        raise RuntimeError(
+            f"EXL3 {what}: mul1 marker is not the mul1 int32 {MUL1_MARKER_SIGNED_INT32}; "
+            "packed ABI mismatch"
+        )
 
 
 class Exl3MoEMethod(FusedMoEMethodBase):
@@ -1641,7 +1812,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             requires_grad=False,
         )
         w13_mcg = Parameter(
-            torch.empty(num_experts, 2, 1, dtype=torch.int32),
+            torch.zeros(num_experts, 2, 1, dtype=torch.int32),
+            requires_grad=False,
+        )
+        w13_mul1 = Parameter(
+            torch.zeros(num_experts, 2, 1, dtype=torch.int32),
             requires_grad=False,
         )
         w2_trellis = Parameter(
@@ -1661,7 +1836,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             requires_grad=False,
         )
         w2_mcg = Parameter(
-            torch.empty(num_experts, 1, dtype=torch.int32),
+            torch.zeros(num_experts, 1, dtype=torch.int32),
+            requires_grad=False,
+        )
+        w2_mul1 = Parameter(
+            torch.zeros(num_experts, 1, dtype=torch.int32),
             requires_grad=False,
         )
 
@@ -1670,10 +1849,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "w13_suh": w13_suh,
             "w13_svh": w13_svh,
             "w13_mcg": w13_mcg,
+            "w13_mul1": w13_mul1,
             "w2_trellis": w2_trellis,
             "w2_suh": w2_suh,
             "w2_svh": w2_svh,
             "w2_mcg": w2_mcg,
+            "w2_mul1": w2_mul1,
         }
         for name, param in packed.items():
             layer.register_parameter(name, param)
@@ -1687,6 +1868,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer._exl3_intermediate_local = intermediate_size_per_partition
         layer._exl3_k_words = k_words
         layer._exl3_bits = self.bits
+        # vLLM's generic RoutedExperts.load_weights treats any 3-D checkpoint
+        # tensor as fused stacked experts and unbinds it per expert; an EXL3
+        # per-expert trellis is 3-D by construction. Route this layer's tensors
+        # through a per-expert loader instead (instance attribute shadows the
+        # class method for AutoWeightsLoader; direct-calling models are unaffected).
+        layer.load_weights = _exl3_routed_experts_loader(layer)
 
     def _load_exl3(
         self,
@@ -1712,7 +1899,17 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         tp_rank, tp_size = _resolve_tp_geometry(owner, layer)
         suffix = _suffix_from_mapped_name(weight_name)
         loaded = loaded_weight.detach().contiguous()
-
+        if suffix in ("mcg", "mul1"):
+            # Codebook markers are scalars ([] or [1]); keep the value per expert
+            # tensor so process_weights_after_loading can pick the codebook.
+            if shard_id in ("w1", "w3"):
+                dest = param.data[expert_id, 0 if shard_id == "w1" else 1]
+            elif shard_id == "w2":
+                dest = param.data[expert_id]
+            else:
+                raise ValueError(f"unknown EXL3 shard_id={shard_id}")
+            dest.fill_(int(loaded.reshape(-1)[0].item()) if loaded.numel() else 0)
+            return True if return_success else None
         if shard_id in ("w1", "w3"):
             shard_idx = 0 if shard_id == "w1" else 1
             sharded = shard_exl3_col(loaded, suffix, tp_rank, tp_size)
@@ -1741,22 +1938,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "w13_suh",
             "w13_svh",
             "w13_mcg",
+            "w13_mul1",
             "w2_trellis",
             "w2_suh",
             "w2_svh",
             "w2_mcg",
+            "w2_mul1",
         ):
             getattr(layer, name)._exl3_owner = layer
-
-        mcg13 = layer.w13_mcg.reshape(-1)
-        mcg2 = layer.w2_mcg.reshape(-1)
-        if not torch.all(mcg13 == MCG_MARKER_SIGNED_INT32) or not torch.all(
-            mcg2 == MCG_MARKER_SIGNED_INT32
-        ):
-            raise RuntimeError(
-                "EXL3 mcg marker is not the MCG int32 0xCBAC1FED / "
-                f"{MCG_MARKER_SIGNED_INT32}; packed ABI mismatch"
-            )
+        _check_moe_codebook_markers(layer.w13_mcg, layer.w13_mul1, "w13")
+        _check_moe_codebook_markers(layer.w2_mcg, layer.w2_mul1, "w2")
 
         n_exp = int(layer.w13_trellis.shape[0])
         inners: list[dict[str, Any]] = []
@@ -1765,22 +1956,44 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 layer.w13_trellis[e, 0],
                 layer.w13_suh[e, 0],
                 layer.w13_svh[e, 0],
-                layer.w13_mcg[e, 0],
+                _moe_marker_or_none(layer.w13_mcg[e, 0]),
+                _moe_marker_or_none(layer.w13_mul1[e, 0]),
             )
             up = make_linear_exl3(
                 layer.w13_trellis[e, 1],
                 layer.w13_suh[e, 1],
                 layer.w13_svh[e, 1],
-                layer.w13_mcg[e, 1],
+                _moe_marker_or_none(layer.w13_mcg[e, 1]),
+                _moe_marker_or_none(layer.w13_mul1[e, 1]),
             )
             down = make_linear_exl3(
                 layer.w2_trellis[e],
                 layer.w2_suh[e],
                 layer.w2_svh[e],
-                layer.w2_mcg[e],
+                _moe_marker_or_none(layer.w2_mcg[e]),
+                _moe_marker_or_none(layer.w2_mul1[e]),
             )
             inners.append({"gate": gate, "up": up, "down": down})
         layer._exl3_inners = inners
+        # Codebook flags (mcg, mul1) per projection for the fused kernel launch;
+        # every expert in a layer must agree.
+        if inners:
+            flags = tuple(
+                bool(getattr(inners[0][w], a, d))
+                for w in ("gate", "up", "down")
+                for a, d in (("mcg", True), ("mul1", False))
+            )
+            for e, inner in enumerate(inners):
+                f_e = tuple(
+                    bool(getattr(inner[w], a, d))
+                    for w in ("gate", "up", "down")
+                    for a, d in (("mcg", True), ("mul1", False))
+                )
+                if f_e != flags:
+                    raise RuntimeError(
+                        f"EXL3 experts disagree on codebook: expert {e} {f_e} vs expert 0 {flags}"
+                    )
+            layer._exl3_codebook_flags = flags
         fused_ok = False
         fused_err = None
         # Native dispatch has its own environment control and must still build
@@ -1859,6 +2072,382 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
 
 
+# ---------------------------------------------------------------------------
+# Row-wise EXL3 embedding tables (exllamav3 n-gram format)
+# ---------------------------------------------------------------------------
+
+NGRAM_ROW_DIM = 160
+NGRAM_MUL1 = 0x83DCD12D
+
+
+def ngram_words_per_row(bits: int) -> int:
+    """Packed int16 words per row: one fp16 scale word plus the K-bit ring bitstream."""
+    return 1 + NGRAM_ROW_DIM * int(bits) // 16
+
+
+def _fp16_from_bits(bits16: int, device) -> torch.Tensor:
+    signed = bits16 - 0x10000 if bits16 >= 0x8000 else bits16
+    return torch.tensor([signed], dtype=torch.int16, device=device).view(torch.float16)
+
+
+# Reimplements the mul1 codebook arithmetic of ExLlamaV3's ngram_codec
+# (Copyright (c) 2025 Turboderp, MIT); see THIRD_PARTY_NOTICES.md.
+def ngram_mul1_codebook(device) -> torch.Tensor:
+    """The 65536-entry mul1 codebook as fp16, as exllamav3's cached table."""
+    state = torch.arange(65536, device=device, dtype=torch.int64)
+    prod = (state * NGRAM_MUL1) & 0xFFFFFFFF
+    h = 1024.0 + (
+        (prod & 0xFF) + ((prod >> 8) & 0xFF) + ((prod >> 16) & 0xFF) + ((prod >> 24) & 0xFF)
+    ).to(torch.float32)
+    k_inv = _fp16_from_bits(0x1EEE, device).to(torch.float32)
+    k_bias = _fp16_from_bits(0xC931, device).to(torch.float32)
+    return (h * k_inv + k_bias).to(torch.float16)
+
+
+def _ngram_bit_tables(bits: int, device) -> tuple[torch.Tensor, torch.Tensor]:
+    """(word index, bit index) of stream bit m of element i.
+
+    Bit m of element i lives at ring position ((i - m // K) mod ROW_DIM) * K + m % K,
+    offset by one for the scale word.
+    """
+    i = torch.arange(NGRAM_ROW_DIM, device=device, dtype=torch.int64).unsqueeze(1)
+    m = torch.arange(16, device=device, dtype=torch.int64).unsqueeze(0)
+    pos = (i - m // bits) % NGRAM_ROW_DIM
+    sb = pos * bits + m % bits
+    return 1 + (sb >> 4), sb & 15
+
+
+# Reimplements the row layout of ExLlamaV3's ngram_codec / ngram_dequant
+# kernel (Copyright (c) 2025 Turboderp, MIT); see THIRD_PARTY_NOTICES.md.
+def ngram_dequant_rows_torch(
+    packed: torch.Tensor,
+    bits: int,
+    heads: torch.Tensor,
+    head_bias: torch.Tensor,
+    chunk: int = 8192,
+) -> torch.Tensor:
+    """Pure-torch twin of ``exllamav3_ext.ngram_dequant`` (fallback and test oracle).
+
+    packed: (N, words) int16; heads: (N,) int; head_bias: (num_heads, ROW_DIM) fp16.
+    Returns (N, ROW_DIM) fp16: codebook[state] * scale + head_bias[head].
+    """
+    device = packed.device
+    widx, bidx = _ngram_bit_tables(bits, device)
+    codebook = ngram_mul1_codebook(device)
+    shifts = torch.arange(16, device=device, dtype=torch.int64)
+    out = torch.empty(packed.shape[0], NGRAM_ROW_DIM, dtype=torch.float16, device=device)
+    for s in range(0, packed.shape[0], chunk):
+        p = packed[s : s + chunk]
+        scale = p[:, 0].contiguous().view(torch.float16).to(torch.float32)
+        words = (p.to(torch.int64) & 0xFFFF)[:, widx]
+        state = (((words >> bidx) & 1) << shifts).sum(-1)
+        vals = codebook[state].to(torch.float32)
+        bias = head_bias[heads[s : s + chunk].to(torch.int64)].to(torch.float32)
+        out[s : s + chunk] = (vals * scale.unsqueeze(1) + bias).to(torch.float16)
+    return out
+
+
+class Exl3EmbeddingMethod(QuantizeMethodBase):
+    """Row-wise EXL3 embedding table in exllamav3's n-gram format.
+
+    Each row is stored packed: word 0 holds the row's fp16 scale, the remaining
+    ROW_DIM * K / 16 int16 words hold a tail-biting ring bitstream of 160 K-bit
+    trellis states. A lookup gathers packed rows and decodes them on the fly
+    (mul1 codebook * scale + per-head bias) into fp16, so the table stays at K
+    bits per weight in device memory (32.6 GB for the Qwen3.8-Flash-Next table
+    instead of 102 GB as bf16). Checkpoint layout under the table prefix:
+    ``shard_<i>.trellis`` int16 [rows_per_shard, words], ``head_bias`` fp16
+    [heads, 160], ``head_offsets`` / ``head_vocab_sizes`` int64 [heads],
+    ``layer_multipliers`` int64 [n]. Shard parameters are registered as child
+    modules so vLLM's AutoWeightsLoader lands them by name; they alias one
+    contiguous table used for the gather.
+    """
+
+    def __init__(self, quant_config: Exl3Config, spec: dict[str, Any]) -> None:
+        self.quant_config = quant_config
+        self.bits = int(spec["bits"])
+        self.num_shards = int(spec["num_shards"])
+        self.rows_per_shard = int(spec["rows_per_shard"])
+        self.num_heads = int(spec["num_heads"])
+        self.words = ngram_words_per_row(self.bits)
+        kernel = os.environ.get("VLLM_EXL3_NGRAM_KERNEL", "ext").strip().lower()
+        if kernel not in ("ext", "torch"):
+            raise ValueError(
+                f"VLLM_EXL3_NGRAM_KERNEL must be 'ext' or 'torch', got {kernel!r}"
+            )
+        self.kernel = kernel
+        self._ext = None
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del input_size, extra_weight_attrs
+        if int(input_size_per_partition) != NGRAM_ROW_DIM:
+            raise ValueError(
+                f"EXL3 n-gram rows are {NGRAM_ROW_DIM} wide; layer asks for "
+                f"{int(input_size_per_partition)}"
+            )
+        total_rows = self.num_shards * self.rows_per_shard
+        parts = [int(s) for s in output_partition_sizes]
+        if int(output_size) != total_rows or parts != [total_rows]:
+            raise ValueError(
+                "EXL3 n-gram table geometry mismatch: vLLM built "
+                f"{int(output_size)} rows (partitions {parts}) but the checkpoint "
+                f"holds {self.num_shards} shards x {self.rows_per_shard} rows = {total_rows}"
+            )
+        _, tp_size = _resolve_tp_geometry(layer)
+        if int(tp_size) != 1:
+            raise RuntimeError("EXL3 n-gram embedding supports tensor parallel size 1 only")
+
+        table = torch.empty(
+            self.num_shards, self.rows_per_shard, self.words, dtype=torch.int16
+        )
+        loaded: set[int] = set()
+        for i in range(self.num_shards):
+            shard = torch.nn.Module()
+            p = Parameter(table[i], requires_grad=False)
+            p.weight_loader = self._make_shard_loader(i, loaded)
+            shard.register_parameter("trellis", p)
+            layer.add_module(f"shard_{i}", shard)
+        aux = {
+            "head_bias": Parameter(
+                torch.zeros(self.num_heads, NGRAM_ROW_DIM, dtype=torch.float16),
+                requires_grad=False,
+            ),
+            "head_offsets": Parameter(
+                torch.full((self.num_heads,), -1, dtype=torch.int64), requires_grad=False
+            ),
+            "head_vocab_sizes": Parameter(
+                torch.zeros(self.num_heads, dtype=torch.int64), requires_grad=False
+            ),
+            "layer_multipliers": Parameter(
+                torch.zeros(0, dtype=torch.int64), requires_grad=False
+            ),
+        }
+        aux_loaded: set[str] = set()
+        for name, p in aux.items():
+            p.weight_loader = self._make_aux_loader(name, aux_loaded)
+            layer.register_parameter(name, p)
+        layer._exl3_ngram_table = table
+        layer._exl3_ngram_loaded = loaded
+        layer._exl3_ngram_aux_loaded = aux_loaded
+        layer._exl3_ngram_dtype = params_dtype
+
+    def _make_shard_loader(self, index: int, loaded: set[int]):
+        rows, words, bits = self.rows_per_shard, self.words, self.bits
+
+        def weight_loader(param: Parameter, loaded_weight: torch.Tensor, loaded_shard_id=None):
+            del loaded_shard_id
+            if loaded_weight.dtype != torch.int16 or tuple(loaded_weight.shape) != (rows, words):
+                raise ValueError(
+                    f"EXL3 n-gram shard {index}: expected int16 ({rows}, {words}) for "
+                    f"K={bits}, got {loaded_weight.dtype} {tuple(loaded_weight.shape)}"
+                )
+            param.data.copy_(loaded_weight)
+            loaded.add(index)
+
+        return weight_loader
+
+    def _make_aux_loader(self, name: str, aux_loaded: set[str]):
+        def weight_loader(param: Parameter, loaded_weight: torch.Tensor, loaded_shard_id=None):
+            del loaded_shard_id
+            if name == "layer_multipliers":
+                param.data = loaded_weight.to(device=param.device, dtype=param.dtype).clone()
+            else:
+                if tuple(loaded_weight.shape) != tuple(param.shape):
+                    raise ValueError(
+                        f"EXL3 n-gram {name}: expected shape {tuple(param.shape)}, "
+                        f"got {tuple(loaded_weight.shape)}"
+                    )
+                param.data.copy_(loaded_weight.to(dtype=param.dtype))
+            aux_loaded.add(name)
+
+        return weight_loader
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        table = getattr(layer, "_exl3_ngram_table", None)
+        if table is None:
+            return
+        loaded = layer._exl3_ngram_loaded
+        missing = [i for i in range(self.num_shards) if i not in loaded]
+        if missing:
+            raise RuntimeError(
+                f"EXL3 n-gram table: {len(missing)} of {self.num_shards} shards never "
+                f"loaded (first missing: {missing[:8]})"
+            )
+        aux_missing = [
+            n for n in ("head_bias", "head_offsets", "head_vocab_sizes")
+            if n not in layer._exl3_ngram_aux_loaded
+        ]
+        if aux_missing:
+            raise RuntimeError(f"EXL3 n-gram table: aux tensors never loaded: {aux_missing}")
+        if layer.shard_0.trellis.data_ptr() != table.data_ptr():
+            raise RuntimeError(
+                "EXL3 n-gram shard parameters no longer alias the packed table; refusing to serve"
+            )
+        offs = layer.head_offsets.detach().cpu().tolist()
+        sizes = layer.head_vocab_sizes.detach().cpu().tolist()
+        total_rows = self.num_shards * self.rows_per_shard
+        consistent = (
+            offs[0] == 0
+            and all(offs[i + 1] == offs[i] + sizes[i] for i in range(len(offs) - 1))
+            and offs[-1] + sizes[-1] <= total_rows
+        )
+        if not consistent:
+            raise RuntimeError(
+                f"EXL3 n-gram head layout inconsistent with the table: offsets={offs} "
+                f"sizes={sizes} rows={total_rows}"
+            )
+        layer._exl3_ngram_rows = table.view(-1, self.words)
+        layer._exl3_ngram_head_offsets = layer.head_offsets.data.contiguous()
+        layer._exl3_ngram_head_bias = layer.head_bias.data.contiguous()
+        layer._exl3_opaque_name = _exl3_register_opaque_layer(layer, "ngram")
+        if self.kernel == "ext":
+            ext = load_exllamav3_ext()
+            if hasattr(ext, "ngram_dequant"):
+                self._ext = ext
+            else:
+                logger.warning(
+                    "exllamav3_ext has no ngram_dequant; the EXL3 n-gram table falls back "
+                    "to the torch decoder"
+                )
+                self.kernel = "torch"
+        logger.info(
+            "EXL3 n-gram embedding ready: %d shards x %d rows, K=%d, %d heads, "
+            "%.2f GiB packed, kernel=%s",
+            self.num_shards, self.rows_per_shard, self.bits, self.num_heads,
+            table.numel() * 2 / 2**30, self.kernel,
+        )
+
+    def _lookup_packed(self, layer: torch.nn.Module, ids_flat: torch.Tensor) -> torch.Tensor:
+        return layer._exl3_ngram_rows.index_select(0, ids_flat)
+
+    def _heads_for(self, layer: torch.nn.Module, ids_flat: torch.Tensor) -> torch.Tensor:
+        found = torch.searchsorted(layer._exl3_ngram_head_offsets, ids_flat, right=True) - 1
+        return found.clamp_(0, self.num_heads - 1).to(torch.int32)
+
+    def _decode(self, layer: torch.nn.Module, packed: torch.Tensor, heads: torch.Tensor) -> torch.Tensor:
+        bias = layer._exl3_ngram_head_bias
+        if self.kernel == "ext" and self._ext is not None:
+            out = torch.empty(
+                packed.shape[0], NGRAM_ROW_DIM, dtype=torch.float16, device=packed.device
+            )
+            self._ext.ngram_dequant(packed, self.bits, heads, bias, out)
+            return out
+        return ngram_dequant_rows_torch(packed, self.bits, heads, bias)
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        name = getattr(layer, "_exl3_opaque_name", None)
+        if name is not None and _EXL3_OPS_READY:
+            return torch.ops.vllm.exl3_ngram_lookup(input_, name)
+        return self._embedding_impl(layer, input_)
+
+    def _embedding_impl(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        if getattr(layer, "_exl3_ngram_rows", None) is None:
+            raise RuntimeError("EXL3 n-gram table was not finalized after weight load")
+        ids = input_.reshape(-1).to(torch.int64)
+        packed = self._lookup_packed(layer, ids)
+        heads = self._heads_for(layer, ids)
+        out = self._decode(layer, packed, heads)
+        return out.to(layer._exl3_ngram_dtype).view(*input_.shape, NGRAM_ROW_DIM)
+
+    def apply(self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None = None):
+        raise NotImplementedError("EXL3 n-gram tables only support embedding lookup")
+
+
+# ---------------------------------------------------------------------------
+# torch.compile opacity: vLLM traces the model forward with fullgraph dynamo, which
+# cannot step into exllamav3's pybind kernels. The dense linear forward and the
+# n-gram lookup run behind vLLM custom ops, looked up by a stable layer name.
+# ---------------------------------------------------------------------------
+
+_EXL3_OPAQUE_LAYERS: dict[str, Any] = {}
+_EXL3_OPS_READY = False
+
+
+def _exl3_register_opaque_layer(layer: torch.nn.Module, kind: str) -> str:
+    stable = (
+        getattr(layer, "_exl3_prefix", None)
+        or getattr(layer, "prefix", None)
+        or getattr(layer, "layer_name", None)
+        or f"id{id(layer)}"
+    )
+    name = f"exl3_{kind}:{stable}"
+    _EXL3_OPAQUE_LAYERS[name] = layer
+    return name
+
+
+def _exl3_linear_forward_op(x: torch.Tensor, layer_name: str) -> torch.Tensor:
+    layer = _EXL3_OPAQUE_LAYERS[layer_name]
+    return layer.quant_method._apply_impl(layer, x)
+
+
+def _exl3_linear_forward_fake(x: torch.Tensor, layer_name: str) -> torch.Tensor:
+    layer = _EXL3_OPAQUE_LAYERS[layer_name]
+    out = int(
+        sum(
+            getattr(
+                layer, "_exl3_linear_true_out", layer._exl3_linear_output_partition_sizes
+            )
+        )
+    )
+    return x.new_empty(*x.shape[:-1], out)
+
+
+def _exl3_ngram_lookup_op(ids: torch.Tensor, layer_name: str) -> torch.Tensor:
+    layer = _EXL3_OPAQUE_LAYERS[layer_name]
+    return layer.quant_method._embedding_impl(layer, ids)
+
+
+def _exl3_ngram_lookup_fake(ids: torch.Tensor, layer_name: str) -> torch.Tensor:
+    layer = _EXL3_OPAQUE_LAYERS[layer_name]
+    return ids.new_empty(*ids.shape, NGRAM_ROW_DIM, dtype=layer._exl3_ngram_dtype)
+
+
+def _exl3_register_custom_ops() -> bool:
+    global _EXL3_OPS_READY
+    if _EXL3_OPS_READY:
+        return True
+    try:
+        try:
+            from vllm.utils.torch_utils import direct_register_custom_op
+        except ImportError:
+            from vllm.utils import direct_register_custom_op
+    except ImportError:
+        return False
+    try:
+        if not hasattr(torch.ops.vllm, "exl3_linear_forward"):
+            direct_register_custom_op(
+                op_name="exl3_linear_forward",
+                op_func=_exl3_linear_forward_op,
+                mutates_args=[],
+                fake_impl=_exl3_linear_forward_fake,
+            )
+        if not hasattr(torch.ops.vllm, "exl3_ngram_lookup"):
+            direct_register_custom_op(
+                op_name="exl3_ngram_lookup",
+                op_func=_exl3_ngram_lookup_op,
+                mutates_args=[],
+                fake_impl=_exl3_ngram_lookup_fake,
+            )
+    except Exception as exc:  # pragma: no cover - registration is best effort
+        logger.warning("EXL3 custom op registration failed; eager fallback: %r", exc)
+        return False
+    _EXL3_OPS_READY = True
+    return True
+
+
+if _VLLM_AVAILABLE and _TORCH_AVAILABLE:
+    _exl3_register_custom_ops()
+
+
 class Exl3LinearMethod(LinearMethodBase):
     """Non-routed (dense) EXL3 linear method for QKV/MLP dense projections.
 
@@ -1917,6 +2506,37 @@ class Exl3LinearMethod(LinearMethodBase):
 
         # K words per shard
         k_words = self.bits * 16
+
+        # EXL3 pads both matrix dims to multiples of 128 (zeros at the end;
+        # padded output columns carry svh = 0, padded input rows only see
+        # zero-extended inputs). Allocate the padded geometry, load the
+        # checkpoint tensors whole, and pad / trim activations in apply().
+        true_in = int(in_per_partition)
+        true_out_sizes = [int(s) for s in output_partition_sizes]
+        in_per_partition = _exl3_pad128(true_in)
+        output_partition_sizes = [_exl3_pad128(s) for s in true_out_sizes]
+        padded = in_per_partition != true_in or output_partition_sizes != true_out_sizes
+        if padded and (bf16_shards or n_shards > 1):
+            raise NotImplementedError(
+                "EXL3 padded linear geometry is supported for single-shard layers "
+                f"without bf16 shards only: in={true_in} out={true_out_sizes}"
+            )
+        if padded:
+            _, _pad_tp = _resolve_tp_geometry(layer)
+            if int(_pad_tp) > 1:
+                raise NotImplementedError(
+                    "EXL3 padded linear geometry requires tensor parallel size 1"
+                )
+            # vLLM registers the bias after create_weights with this instance's
+            # weight_loader; a padded checkpoint bias is trimmed to the true size.
+            _orig_loader = layer.weight_loader
+
+            def _bias_trim_loader(param, loaded_weight, *args, **kwargs):
+                if param.dim() == 1 and int(loaded_weight.shape[0]) > int(param.shape[0]):
+                    loaded_weight = loaded_weight[: int(param.shape[0])]
+                return _orig_loader(param, loaded_weight, *args, **kwargs)
+
+            layer.weight_loader = _bias_trim_loader
 
         # Validate tile alignment for all shards
         for i, out_size in enumerate(output_partition_sizes):
@@ -2014,6 +2634,9 @@ class Exl3LinearMethod(LinearMethodBase):
         layer._exl3_linear_is_qkv = is_qkv_parallel
         layer._exl3_linear_is_merged = is_merged_col_parallel
         layer._exl3_linear_bf16_shards = bf16_shards
+        layer._exl3_linear_padded = padded
+        layer._exl3_linear_true_in = true_in
+        layer._exl3_linear_true_out = true_out_sizes
 
     def _make_weight_loader(
         self,
@@ -2033,6 +2656,66 @@ class Exl3LinearMethod(LinearMethodBase):
             loaded_shard_id: str | int | None = None,
         ) -> None:
             tp_rank, tp_size = _resolve_tp_geometry(layer, param)
+
+            # One checkpoint tensor may span several consecutive shards; vLLM's
+            # WeightsMapper says so with a tuple of shard ids (Qwen3.5/4
+            # in_proj_qkv -> in_proj_qkvz shards (0, 1, 2)). Split it along the
+            # output dimension at the shard boundaries and load each piece.
+            span_ids = None
+            if isinstance(loaded_shard_id, (tuple, list)):
+                span_ids = [int(i) for i in loaded_shard_id]
+            elif loaded_shard_id is None and n_shards > 1:
+                # Already-fused checkpoint tensor on a merged linear: an
+                # output-sized tensor covering every shard is split; per-input
+                # tensors and markers apply to every shard.
+                if suffix in ("suh", "mcg", "mul1"):
+                    span_ids = list(range(n_shards))
+                else:
+                    loaded_out = (
+                        int(loaded_weight.shape[1]) * 16
+                        if suffix == "trellis"
+                        else int(loaded_weight.shape[0])
+                    )
+                    if loaded_out == sum(output_partition_sizes) and loaded_out != int(
+                        output_partition_sizes[0]
+                    ):
+                        span_ids = list(range(n_shards))
+            if span_ids is not None:
+                ids = span_ids
+                if (
+                    not ids
+                    or ids != list(range(ids[0], ids[0] + len(ids)))
+                    or ids[-1] >= n_shards
+                ):
+                    raise ValueError(
+                        f"EXL3 linear: unsupported shard id span {loaded_shard_id} "
+                        f"for n_shards={n_shards}"
+                    )
+                if suffix in ("suh", "mcg", "mul1"):
+                    for i in ids:
+                        weight_loader(param, loaded_weight, i)
+                    return
+                loaded_out = (
+                    int(loaded_weight.shape[1]) * 16
+                    if suffix == "trellis"
+                    else int(loaded_weight.shape[0])
+                )
+                span = sum(output_partition_sizes[i] for i in ids)
+                if loaded_out != span:
+                    raise RuntimeError(
+                        f"EXL3 linear load: {suffix} tensor covers {loaded_out} outputs "
+                        f"but shards {ids} total {span}"
+                    )
+                start = 0
+                for i in ids:
+                    size = output_partition_sizes[i]
+                    if suffix == "trellis":
+                        piece = loaded_weight[:, start // 16 : (start + size) // 16, :]
+                    else:
+                        piece = loaded_weight[start : start + size]
+                    weight_loader(param, piece, i)
+                    start += size
+                return
 
             # Map shard_id to shard index
             shard_idx = 0
@@ -2221,6 +2904,7 @@ class Exl3LinearMethod(LinearMethodBase):
             linears.append(linear)
 
         layer._exl3_linears = linears
+        layer._exl3_opaque_name = _exl3_register_opaque_layer(layer, "linear")
 
         # Keep bf16 weights if present, remove weight staging param if all loaded
         if bf16_shards and hasattr(layer, "weight"):
@@ -2254,6 +2938,16 @@ class Exl3LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        name = getattr(layer, "_exl3_opaque_name", None)
+        if name is not None and _EXL3_OPS_READY:
+            y = torch.ops.vllm.exl3_linear_forward(x, name)
+        else:
+            y = self._apply_impl(layer, x)
+        if bias is not None:
+            y = y + bias
+        return y
+
+    def _apply_impl(self, layer, x: torch.Tensor) -> torch.Tensor:
         linears = getattr(layer, "_exl3_linears", None)
         if not linears:
             raise RuntimeError("EXL3 linear layers were not built after weight load")
@@ -2272,6 +2966,10 @@ class Exl3LinearMethod(LinearMethodBase):
 
         # Cast to contiguous fp16 for EXL3 shards
         x_fp16 = x_2d.to(torch.float16).contiguous()
+        if getattr(layer, "_exl3_linear_padded", False):
+            pad_in = int(layer._exl3_linear_input_size_per_partition) - int(x_fp16.shape[1])
+            if pad_in > 0:
+                x_fp16 = F.pad(x_fp16, (0, pad_in))
 
         # Get bf16 shards and weight if present
         bf16_shards = getattr(layer, "_exl3_linear_bf16_shards", [])
@@ -2308,12 +3006,12 @@ class Exl3LinearMethod(LinearMethodBase):
         else:
             y = outputs[0]
 
+        # Trim padded output columns (svh = 0 there, so they are zeros)
+        if getattr(layer, "_exl3_linear_padded", False):
+            y = y[:, : sum(layer._exl3_linear_true_out)]
+
         # Cast back to input dtype
         y = y.to(dtype=x.dtype)
-
-        # Add bias if provided
-        if bias is not None:
-            y = y + bias
 
         # Restore original shape
         if len(orig_shape) > 2:

--- a/src/vllm_exl3/exl3.py
+++ b/src/vllm_exl3/exl3.py
@@ -805,13 +805,15 @@ def _native_moe_dimensions_supported(
 #   K=4:  m=1 1.28x   m=2 1.00x   m=4 1.01x   m=8 0.89x
 #
 # The native ABI takes one row per launch, so cost grows linearly with rows while exl3_moe
-# batches them in a single launch. Dispatch is therefore capped per bit width at the largest
-# row count that still measured a win. Receipt: tools/receipts/ab_moe_gb10.json.
+# batches them in a single launch. Those measurements predate the current native kernels,
+# so the per-bit cap is opt-in (VLLM_EXL3_NATIVE_MOE_MEASURED_CAP=1) and the default keeps
+# the dispatch contract of up to 8 decode rows. Receipt: tools/receipts/ab_moe_gb10.json.
 _NATIVE_MOE_MAX_ROWS = {2: 8, 3: 1, 4: 1}
+_NATIVE_MOE_CONTRACT_ROWS = 8
 
 
 def _native_moe_max_rows(bits: int) -> int:
-    """Largest decode row count where the native kernel measured faster than exl3_moe."""
+    """Decode row cap for native dispatch: env override, measured cap when opted in, else 8."""
     override = os.environ.get("VLLM_EXL3_NATIVE_MOE_MAX_ROWS")
     if override:
         try:
@@ -822,7 +824,9 @@ def _native_moe_max_rows(bits: int) -> int:
             )
         else:
             return max(0, value)
-    return _NATIVE_MOE_MAX_ROWS.get(int(bits), 1)
+    if os.environ.get("VLLM_EXL3_NATIVE_MOE_MEASURED_CAP", "0") == "1":
+        return _NATIVE_MOE_MAX_ROWS.get(int(bits), _NATIVE_MOE_CONTRACT_ROWS)
+    return _NATIVE_MOE_CONTRACT_ROWS
 
 
 def _apply_native_fused_moe(

--- a/tests/test_attribution_and_sanitization.py
+++ b/tests/test_attribution_and_sanitization.py
@@ -54,12 +54,12 @@ def test_upstream_attribution_present():
 
 
 def test_package_version_and_metadata():
-    """Verify version 0.3.1 in pyproject.toml and setup.py."""
+    """Verify version 0.4.0 in pyproject.toml and setup.py."""
     pyproject_path = os.path.join(REPO_ROOT, "pyproject.toml")
     with open(pyproject_path, "r", encoding="utf-8") as f:
         pyproject = f.read()
 
-    assert 'version = "0.3.1"' in pyproject, "pyproject.toml version is not 0.3.1"
+    assert 'version = "0.4.0"' in pyproject, "pyproject.toml version is not 0.4.0"
     assert 'name = "vllm-exl3"' in pyproject, "pyproject.toml name is not vllm-exl3"
 
     setup_path = os.path.join(REPO_ROOT, "setup.py")

--- a/tests/test_native_pack_unit.py
+++ b/tests/test_native_pack_unit.py
@@ -1,0 +1,99 @@
+"""CPU-only unit tests for native-pack support: padding, n-gram row geometry,
+config validation, codebook marker checks, opaque-op registration, and the
+dense linear weight loader's shard-span handling.
+"""
+
+import importlib.util
+import os
+
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXL3_PATH = os.path.join(_HERE, "..", "src", "vllm_exl3", "exl3.py")
+
+_spec = importlib.util.spec_from_file_location("_exl3_native_pack_unit", _EXL3_PATH)
+X = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(X)
+
+
+def test_pad128():
+    assert X._exl3_pad128(4304) == 4352
+    assert X._exl3_pad128(2560) == 2560
+
+
+def test_ngram_words_per_row():
+    assert X.ngram_words_per_row(5) == 51
+    assert X.ngram_words_per_row(3) == 31
+
+
+def test_ngram_embedding_config_and_lookup():
+    cfg = X.Exl3Config(
+        bits=3,
+        codebook="mul1",
+        ngram_embedding={
+            "bits": 5,
+            "num_shards": 4,
+            "rows_per_shard": 1024,
+            "num_heads": 2,
+            "modules": ["ngram_embedding"],
+        },
+    )
+    spec = cfg._ngram_embedding_spec("model.layers.1.ple.ple_embedding.ngram_embedding")
+    assert spec is not None
+    assert spec["bits"] == 5
+
+    assert cfg._ngram_embedding_spec("model.layers.1.ple.kv_proj") is None
+
+    with pytest.raises(ValueError):
+        X.Exl3Config(bits=3, codebook="mcg", ngram_embedding={"bits": 0})
+
+
+def test_check_moe_codebook_markers():
+    n = 4
+    zeros = torch.zeros(n, 1, dtype=torch.int32)
+    mul1_all = torch.full((n, 1), X.MUL1_MARKER_SIGNED_INT32, dtype=torch.int32)
+    mcg_all = torch.full((n, 1), X.MCG_MARKER_SIGNED_INT32, dtype=torch.int32)
+
+    # All mul1: ok.
+    X._check_moe_codebook_markers(zeros, mul1_all, "test")
+    # All mcg: ok.
+    X._check_moe_codebook_markers(mcg_all, zeros, "test")
+    # Neither set: raises.
+    with pytest.raises(RuntimeError):
+        X._check_moe_codebook_markers(zeros, zeros, "test")
+    # Both set: raises.
+    with pytest.raises(RuntimeError):
+        X._check_moe_codebook_markers(mcg_all, mul1_all, "test")
+
+
+def test_register_opaque_layer():
+    layer = torch.nn.Module()
+    layer.prefix = "model.layers.0.mlp.gate_proj"
+    name = X._exl3_register_opaque_layer(layer, "linear")
+    assert name == f"exl3_linear:{layer.prefix}"
+
+
+def test_dense_loader_span_split():
+    cfg = X.Exl3Config(bits=2, codebook="mcg")
+    m = X.Exl3LinearMethod(cfg, bits=2)
+
+    layer = torch.nn.Module()
+    layer.tp_rank = 0
+    layer.tp_size = 1
+
+    loader = m._make_weight_loader("svh", 3, [16, 16, 32], False, [], layer, False)
+
+    param = torch.nn.Parameter(torch.zeros(64, dtype=torch.float16), requires_grad=False)
+    loader(param, torch.arange(64, dtype=torch.float16), (0, 1, 2))
+    assert torch.equal(param.data, torch.arange(64, dtype=torch.float16))
+
+    param2 = torch.nn.Parameter(torch.zeros(64, dtype=torch.float16), requires_grad=False)
+    loader(param2, torch.arange(64, dtype=torch.float16), None)
+    assert torch.equal(param2.data, torch.arange(64, dtype=torch.float16))
+
+    bad_param = torch.nn.Parameter(torch.zeros(64, dtype=torch.float16), requires_grad=False)
+    with pytest.raises(RuntimeError):
+        loader(bad_param, torch.arange(10, dtype=torch.float16), (0, 1))

--- a/tools/exl3_pack_tools/README.md
+++ b/tools/exl3_pack_tools/README.md
@@ -1,0 +1,46 @@
+# tools/exl3_pack_tools
+
+Tools for pointing this plugin at a pack quantized directly by turboderp's own
+ExLlamaV3 tooling ("native" packs), rather than one produced by this
+project's own conversion path. A native pack can carry a fractional average
+bit width (e.g. 3.05 bpw) by assigning bits per tensor, so it needs its
+`config.json` rewritten into the vocabulary the plugin already understands
+before vLLM can load it.
+
+- `qwen_pack_scan.py` inventories every tensor in the pack by reading each
+  `*.safetensors` header only (no tensor data). It reports, per MoE layer,
+  the set of K values across experts for gate/up/down (the plugin stacks a
+  layer's experts into one tensor, so it needs them uniform); per dense
+  linear (attention, dense MLP, shared expert, `lm_head`), its K; and for
+  each row-wise n-gram embedding table, its shard count, row count, K and
+  auxiliary tensors. Writes `pack_scan.json` next to the pack.
+
+  `python3 qwen_pack_scan.py <pack_dir> [--out scan.json]`
+
+- `qwen_pack_config.py` reads that scan and rewrites `config.json`'s
+  `quantization_config` into the plugin's own fields: `layer_bits` (per-layer
+  expert K overrides), `non_routed_exl3.layers` (a per-prefix bit map for
+  dense linears), and `ngram_embedding` (the row-wise table spec). It refuses
+  (exit 2) if any MoE layer's experts disagree on K, or if the pack's n-gram
+  tables have inconsistent geometry, since the plugin cannot represent
+  either case. The original block is kept under `native_quantization_config`
+  and `config.json` is backed up to `config.json.native` first.
+
+  `python3 qwen_pack_config.py <pack_dir> [--scan pack_scan.json] [--dry-run]`
+
+- `regenerate_safetensors_index.py` rebuilds
+  `model.safetensors.index.json` from the safetensors files actually present
+  in the pack directory. **This is a hard requirement**: vLLM's loader trusts
+  the index's `weight_map` over the files on disk, so if the shipped index
+  still names files that were renamed, split, or dropped while assembling a
+  native pack, vLLM silently skips or mis-sources tensors instead of
+  failing loudly. Run this any time the pack's file set changes. It sums
+  each tensor's `data_offsets` span into `metadata.total_size`, backs the
+  original index up to `model.safetensors.index.json.native` (only if that
+  backup does not already exist), and refuses (exit 2) if the same tensor
+  name appears in more than one shard.
+
+  `python3 regenerate_safetensors_index.py <pack_dir> [--dry-run]`
+
+Typical order: scan, rewrite the config, regenerate the index, then run the
+gates in `tools/verify_native_pack/` before booting a server.

--- a/tools/exl3_pack_tools/qwen_pack_config.py
+++ b/tools/exl3_pack_tools/qwen_pack_config.py
@@ -1,0 +1,178 @@
+"""Express a turboderp-native EXL3 pack in the vllm-exl3 plugin's own config vocabulary.
+
+The plugin already understands a base K plus per-layer overrides (`layer_bits`) for experts, a
+per-prefix bit map for dense linears (`non_routed_exl3.layers`), and a row-wise n-gram table
+spec (`ngram_embedding`). A native pack with a fractional average (3.05 bpw) is just those maps
+with a varying K, so no plugin code needs to change as long as every MoE layer's experts share
+one K. This reads the header scan, checks that, and rewrites config.json's quantization_config
+accordingly. The original block is preserved under `native_quantization_config` and
+config.json is backed up to config.json.native first.
+
+Refuses (exit 2) if any MoE layer has experts at different K, because the plugin stacks a
+layer's experts into one tensor and cannot hold mixed widths, or if the pack holds n-gram
+tables of differing geometry (the plugin takes one spec).
+
+usage: python3 qwen_pack_config.py <pack_dir> [--scan pack_scan.json] [--dry-run]
+"""
+import argparse
+import collections
+import json
+import os
+import re
+import shutil
+import sys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("pack")
+    ap.add_argument("--scan", default=None)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    scan_path = args.scan or os.path.join(args.pack, "pack_scan.json")
+    scan = json.load(open(scan_path))
+    cfg_path = os.path.join(args.pack, "config.json")
+    cfg = json.load(open(cfg_path))
+    holder = cfg.get("text_config", cfg)
+    q = holder.get("quantization_config") or cfg.get("quantization_config") or {}
+    if q.get("native_quantization_config"):
+        # config.json was already rewritten by this tool; start from the native block
+        q = q["native_quantization_config"]
+
+    if scan["expert_k_nonuniform"]:
+        print("REFUSE: experts within a layer have different K; plugin cannot stack them:")
+        for r in scan["expert_k_nonuniform"][:10]:
+            print(f"  layer {r['layer']} {r['proj']}: {r['ks']}")
+        return 2
+    if scan.get("ngram_problems"):
+        print("REFUSE: n-gram table problems:")
+        for p in scan["ngram_problems"]:
+            print("  ", p)
+        return 2
+
+    # one K per layer (gate/up/down must agree too, since the plugin uses one K per layer)
+    layer_k = {}
+    disagree = []
+    for layer, row in scan["expert_k_per_layer"].items():
+        ks = {row[p][0] for p in row}
+        if len(ks) != 1:
+            disagree.append((layer, row))
+        else:
+            layer_k[int(layer)] = ks.pop()
+    if disagree:
+        print("REFUSE: gate/up/down experts differ in K within a layer:")
+        for layer, row in disagree[:10]:
+            print(f"  layer {layer}: {row}")
+        return 2
+
+    base = collections.Counter(layer_k.values()).most_common(1)[0][0]
+    layer_bits = {str(l): k for l, k in sorted(layer_k.items()) if k != base}
+
+    # vLLM fuses some checkpoint projections into one module (packed_modules_mapping in
+    # qwen4_exp), and its module prefixes differ from checkpoint names, so emit the map under
+    # every plausible name: raw checkpoint prefix, the fused module it lands in, and both the
+    # checkpoint root and the vLLM-side root. Extra keys are harmless; a missing one leaves a
+    # layer unquantized and the load fails on a missing .weight.
+    fused = {
+        "q_proj": "qkv_proj", "k_proj": "qkv_proj", "v_proj": "qkv_proj",
+        "gate_proj": "gate_up_proj", "up_proj": "gate_up_proj",
+        "in_proj_qkv": "in_proj_qkvz", "in_proj_z": "in_proj_qkvz",
+        "in_proj_b": "in_proj_ba", "in_proj_a": "in_proj_ba",
+        "key_proj": "kv_proj", "value_proj": "kv_proj",
+    }
+    roots = [("model.language_model.", "language_model.model."),
+             ("model.language_model.", "model."),
+             ("model.visual.", "visual."), ("model.visual.", "vision_model.")]
+    # vLLM numbers the MTP draft's layers after the main stack (checkpoint mtp.layers.0 is
+    # module mtp.layers.<num_hidden_layers>), so emit those names too.
+    n_main = int(holder.get("num_hidden_layers") or cfg.get("num_hidden_layers") or 0)
+    mtp_re = re.compile(r"^mtp\.layers\.(\d+)\.")
+    dense_layers = {}
+    suffixes = set()
+    for prefix, k in scan["dense_k_by_prefix"].items():
+        variants = {prefix}
+        head, _, leaf = prefix.rpartition(".")
+        if leaf in fused:
+            variants.add(f"{head}.{fused[leaf]}")
+        for v in list(variants):
+            for src, dst in roots:
+                if v.startswith(src):
+                    variants.add(dst + v[len(src):])
+        if n_main:
+            for v in list(variants):
+                m = mtp_re.match(v)
+                if m:
+                    variants.add(f"mtp.layers.{n_main + int(m.group(1))}." + v[m.end():])
+        for v in variants:
+            dense_layers[v] = {"bits": int(k)}
+            tail = v.split(".")
+            suffixes.add(".".join(tail[-2:]) if len(tail) >= 2 else v)
+
+    codebook = str(q.get("codebook", "mcg"))
+    k_counts = collections.Counter(int(k) for k in scan["dense_k_by_prefix"].values())
+    dense_default = k_counts.most_common(1)[0][0]
+    new_q = {
+        "quant_method": "exl3",
+        "bits": int(base),
+        "codebook": codebook,
+        "head_bits": int(q.get("head_bits", 16)),
+        "scope": "native_all_linears",
+        "layer_bits": layer_bits,
+        "non_routed_exl3": {
+            "codebook": codebook,
+            "bits": int(dense_default),
+            "modules": sorted(suffixes),
+            "layers": dense_layers,
+        },
+        "native_quantization_config": q,
+        "derived_from_headers": os.path.basename(scan_path),
+    }
+
+    # Row-wise n-gram tables: one spec, matched by module leaf name; all tables must agree.
+    tables = scan.get("ngram_tables") or {}
+    if tables:
+        geoms = {(t["bits"], t["num_shards"], t["rows_per_shard"]) for t in tables.values()}
+        if len(geoms) != 1:
+            print("REFUSE: n-gram tables differ in geometry:", geoms)
+            return 2
+        heads = set()
+        for t in tables.values():
+            hb = t["aux"].get("head_bias")
+            if not hb or len(hb["shape"]) != 2 or hb["shape"][1] != 160:
+                print("REFUSE: n-gram table without a [heads, 160] head_bias:", t["aux"])
+                return 2
+            heads.add(int(hb["shape"][0]))
+        if len(heads) != 1:
+            print("REFUSE: n-gram tables differ in head count:", heads)
+            return 2
+        bits, num_shards, rows = next(iter(geoms))
+        new_q["ngram_embedding"] = {
+            "bits": int(bits),
+            "num_shards": int(num_shards),
+            "rows_per_shard": int(rows),
+            "num_heads": heads.pop(),
+            "modules": sorted({r.rsplit(".", 1)[-1] for r in tables}),
+        }
+
+    print(f"experts: base K={base}, layer overrides={len(layer_bits)} {layer_bits if len(layer_bits) < 20 else '(many)'}")
+    print(f"dense linears mapped: {len(dense_layers)}; K distribution:",
+          dict(collections.Counter(v['bits'] for v in dense_layers.values())))
+    print(f"codebook={codebook} head_bits={new_q['head_bits']}")
+    print("ngram_embedding:", new_q.get("ngram_embedding"))
+    if args.dry_run:
+        print("dry run, config.json untouched")
+        return 0
+
+    backup = cfg_path + ".native"
+    if not os.path.exists(backup):
+        shutil.copyfile(cfg_path, backup)
+    if "text_config" in cfg and "quantization_config" in cfg["text_config"]:
+        cfg["text_config"]["quantization_config"] = new_q
+    cfg["quantization_config"] = new_q
+    json.dump(cfg, open(cfg_path, "w"), indent=2)
+    print(f"written {cfg_path} (backup {backup})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/exl3_pack_tools/qwen_pack_scan.py
+++ b/tools/exl3_pack_tools/qwen_pack_scan.py
@@ -1,0 +1,178 @@
+"""Inventory a turboderp-native EXL3 pack's tensors so the plugin's config can be derived.
+
+The vllm-exl3 plugin stacks a layer's experts into one [E, in/16, out/16, 16*K] tensor, so it
+needs a single K per MoE layer. exl3 packs quantized to a fractional average (3.05 bpw) assign K
+per tensor. This reads every safetensors header (no tensor data) and reports:
+  - per MoE layer: the set of K values across experts for gate/up/down (uniform or not)
+  - per dense linear (attention, dense MLP, shared expert, lm_head): K and suffixes
+  - row-wise n-gram embedding tables (exllamav3 ngram format): shard count, rows, K, aux tensors
+  - every tensor suffix seen per module family, so extra tensors the plugin ignores show up
+
+K for a linear trellis tensor is shape[-1] // 16. An n-gram table row is 1 + 160*K/16 int16
+words, so for `<root>.shard_N.trellis` [rows, words] K = (words - 1) * 16 // 160; those
+tensors are reported under `ngram_tables` and kept out of the dense-linear map.
+Writes a JSON summary next to stdout.
+
+usage: python3 qwen_pack_scan.py <pack_dir> [--out scan.json]
+"""
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import struct
+import sys
+
+NGRAM_ROW_DIM = 160
+
+
+def headers(pack):
+    for shard in sorted(glob.glob(os.path.join(pack, "*.safetensors"))):
+        with open(shard, "rb") as f:
+            n = struct.unpack("<Q", f.read(8))[0]
+            hdr = json.loads(f.read(n))
+        for name, meta in hdr.items():
+            if name == "__metadata__":
+                continue
+            yield os.path.basename(shard), name, meta.get("dtype"), meta.get("shape") or []
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("pack")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    out = args.out or os.path.join(args.pack, "pack_scan.json")
+
+    layer_re = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+    expert_re = re.compile(r"\.experts\.(\d+)\.(\w+)\.(\w+)$")
+    ngram_re = re.compile(r"^(.*)\.shard_(\d+)\.trellis$")
+    tensors = list(headers(args.pack))
+
+    # n-gram tables first: roots are discovered from shard trellis names, then every
+    # tensor directly under a root that is not a shard is an aux tensor of that table.
+    ngram = {}
+    for _, name, dtype, shape in tensors:
+        m = ngram_re.match(name)
+        if m and len(shape) == 2:
+            t = ngram.setdefault(m.group(1), {"shards": set(), "shapes": set(), "dtypes": set(), "aux": {}})
+            t["shards"].add(int(m.group(2)))
+            t["shapes"].add((int(shape[0]), int(shape[1])))
+            t["dtypes"].add(dtype)
+    for _, name, dtype, shape in tensors:
+        for root, t in ngram.items():
+            if name.startswith(root + ".") and ".shard_" not in name[len(root):]:
+                t["aux"][name[len(root) + 1:]] = {"dtype": dtype, "shape": [int(s) for s in shape]}
+    ngram_tables = {}
+    ngram_problems = []
+    for root, t in ngram.items():
+        shards = sorted(t["shards"])
+        if shards != list(range(len(shards))):
+            ngram_problems.append(f"{root}: shard indices not contiguous ({shards[:5]}...)")
+        if len(t["shapes"]) != 1 or t["dtypes"] != {"I16"}:
+            ngram_problems.append(f"{root}: shard shapes/dtypes not uniform: {t['shapes']} {t['dtypes']}")
+            continue
+        rows, words = next(iter(t["shapes"]))
+        if (words - 1) * 16 % NGRAM_ROW_DIM:
+            ngram_problems.append(f"{root}: words={words} is not 1 + 160*K/16")
+            continue
+        ngram_tables[root] = {
+            "num_shards": len(shards),
+            "rows_per_shard": rows,
+            "words": words,
+            "bits": (words - 1) * 16 // NGRAM_ROW_DIM,
+            "total_rows": len(shards) * rows,
+            "aux": t["aux"],
+        }
+    ngram_roots = tuple(ngram)
+
+    families = collections.defaultdict(set)      # module family -> suffixes seen
+    expert_k = collections.defaultdict(lambda: collections.defaultdict(set))  # layer -> proj -> {K}
+    dense_k = {}                                   # module prefix -> K
+    misc = collections.Counter()
+    total = 0
+    for shard, name, dtype, shape in tensors:
+        total += 1
+        if ngram_roots and name.startswith(tuple(r + "." for r in ngram_roots)):
+            fam = re.sub(r"\.\d+\.", ".N.", name.rsplit(".", 1)[0])
+            fam = re.sub(r"\.shard_\d+$", ".shard_N", fam)
+            families[fam].add(name.rsplit(".", 1)[-1])
+            continue
+        if name.endswith(".trellis"):
+            k = int(shape[-1]) // 16 if shape else None
+        else:
+            k = None
+        m = expert_re.search(name)
+        lm = layer_re.search(name)
+        if m and lm:
+            layer, proj, suffix = int(lm.group(1)), m.group(2), m.group(3)
+            families[f"layers.N.experts.E.{proj}"].add(suffix)
+            if k is not None:
+                expert_k[layer][proj].add(k)
+            continue
+        base = name.rsplit(".", 1)[0]
+        suffix = name.rsplit(".", 1)[-1]
+        fam = re.sub(r"\.\d+\.", ".N.", base)
+        families[fam].add(suffix)
+        if k is not None:
+            dense_k[base] = k
+        if not lm and not name.startswith("mtp"):
+            misc[fam] += 1
+
+    per_layer = {}
+    nonuniform = []
+    for layer in sorted(expert_k):
+        row = {}
+        for proj in sorted(expert_k[layer]):
+            ks = sorted(expert_k[layer][proj])
+            row[proj] = ks
+            if len(ks) != 1:
+                nonuniform.append((layer, proj, ks))
+        per_layer[layer] = row
+
+    dense_by_fam = collections.defaultdict(collections.Counter)
+    for base, k in dense_k.items():
+        dense_by_fam[re.sub(r"\.\d+\.", ".N.", base)][k] += 1
+
+    summary = {
+        "pack": args.pack,
+        "tensors": total,
+        "moe_layers": len(per_layer),
+        "expert_k_per_layer": {str(l): r for l, r in per_layer.items()},
+        "expert_k_nonuniform": [{"layer": l, "proj": p, "ks": ks} for l, p, ks in nonuniform],
+        "dense_k_by_family": {f: dict(c) for f, c in sorted(dense_by_fam.items())},
+        "dense_k_by_prefix": dense_k,
+        "ngram_tables": ngram_tables,
+        "ngram_problems": ngram_problems,
+        "suffixes_by_family": {f: sorted(s) for f, s in sorted(families.items())},
+        "non_layer_families": dict(misc),
+    }
+    json.dump(summary, open(out, "w"), indent=1)
+
+    print(f"tensors={total} moe_layers={len(per_layer)} nonuniform_expert_layers={len(nonuniform)}")
+    kd = collections.Counter()
+    for l, r in per_layer.items():
+        for p, ks in r.items():
+            kd[tuple(ks)] += 1
+    print("expert K distribution (per layer/proj):", dict(kd))
+    if nonuniform:
+        print("NONUNIFORM expert K within a layer (plugin cannot stack these):")
+        for l, p, ks in nonuniform[:12]:
+            print(f"  layer {l} {p}: {ks}")
+    print("dense K by family:")
+    for f, c in sorted(dense_by_fam.items()):
+        print(f"  {f}: {dict(c)}")
+    print("n-gram tables:")
+    for root, t in ngram_tables.items():
+        print(f"  {root}: {t['num_shards']} shards x {t['rows_per_shard']} rows, words={t['words']} K={t['bits']}, aux={sorted(t['aux'])}")
+    for p in ngram_problems:
+        print("  PROBLEM:", p)
+    print("suffixes by family:")
+    for f, s in sorted(families.items()):
+        print(f"  {f}: {sorted(s)}")
+    print("written:", out)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/exl3_pack_tools/regenerate_safetensors_index.py
+++ b/tools/exl3_pack_tools/regenerate_safetensors_index.py
@@ -1,0 +1,86 @@
+"""Rebuild model.safetensors.index.json from the safetensors files actually present.
+
+A native EXL3 pack's tensors (trellis / suh / svh / mcg / mul1 / n-gram shards) are pulled from
+turboderp's own shard files, and the resulting file set frequently no longer matches the index
+that shipped with the source checkpoint: files get renamed, split, or dropped, and the index's
+weight_map still names the old files. vLLM's loader trusts the index over `glob`, so a stale
+index makes it skip or mis-source tensors silently rather than fail loudly.
+
+This reads every `*.safetensors` header (the 8-byte little-endian length prefix, then that many
+bytes of JSON -- no tensor data is touched) in a pack directory and writes a fresh
+model.safetensors.index.json: `metadata.total_size` is the sum of each tensor's
+`data_offsets` span, and `weight_map` names every tensor's file. The original index, if any, is
+backed up to `model.safetensors.index.json.native` (not overwritten if that backup already
+exists, so re-running is safe). Refuses (exit 2) if the same tensor name appears in more than
+one shard, since the index format cannot represent that and something upstream is wrong.
+
+usage: python3 regenerate_safetensors_index.py <pack_dir> [--dry-run]
+"""
+import argparse
+import glob
+import json
+import os
+import shutil
+import struct
+import sys
+
+
+def read_header(path):
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(n))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("pack")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    shards = sorted(glob.glob(os.path.join(args.pack, "*.safetensors")))
+    if not shards:
+        print(f"ERROR: no *.safetensors files under {args.pack}")
+        return 2
+
+    weight_map = {}
+    total_size = 0
+    dupes = []
+    for shard in shards:
+        base = os.path.basename(shard)
+        header = read_header(shard)
+        for name, meta in header.items():
+            if name == "__metadata__":
+                continue
+            if name in weight_map:
+                dupes.append((name, weight_map[name], base))
+                continue
+            weight_map[name] = base
+            offsets = meta.get("data_offsets") or [0, 0]
+            total_size += int(offsets[1]) - int(offsets[0])
+
+    if dupes:
+        print(f"REFUSE: {len(dupes)} tensor name(s) appear in more than one shard:")
+        for name, first, second in dupes[:10]:
+            print(f"  {name}: {first} and {second}")
+        return 2
+
+    print(f"scanned {len(shards)} shard(s), {len(weight_map)} tensor(s), total_size={total_size}")
+    if args.dry_run:
+        return 0
+
+    index_path = os.path.join(args.pack, "model.safetensors.index.json")
+    backup_path = index_path + ".native"
+    if os.path.exists(index_path) and not os.path.exists(backup_path):
+        shutil.copyfile(index_path, backup_path)
+        print(f"backed up existing index to {backup_path}")
+
+    index = {"metadata": {"total_size": total_size}, "weight_map": weight_map}
+    with open(index_path, "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print(f"wrote {index_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/patch_vllm_qwen4_exp/README.md
+++ b/tools/patch_vllm_qwen4_exp/README.md
@@ -1,0 +1,37 @@
+# tools/patch_vllm_qwen4_exp
+
+Three small, idempotent patches to vLLM's own `Qwen4ExpForConditionalGeneration`
+model code (`vllm/model_executor/models/qwen4_exp/nvidia/`), needed so the
+plugin's `get_quant_method` is actually consulted for the layers a native EXL3
+pack quantizes outside the routed experts. Each script takes the path to a
+vLLM `site-packages/vllm` directory, checks whether it has already been
+applied, compile-checks the patched source before writing it, and keeps a
+backup of the original file (`.orig` / `.orig2`) so the patch can be reverted
+by hand.
+
+- `patch_vllm_qwen4_ple.py` adds `quant_config=` to the `ParallelLMHead` and
+  `PLEVocabParallelEmbedding` constructors in `model.py` and `ple_layer.py`.
+  Without it vLLM builds both layers unquantized regardless of
+  `--quantization`, so a pack whose `lm_head` and n-gram table rows are EXL3
+  trellis tensors cannot load: the quant config never gets asked for a method,
+  and the layer expects a plain `lm_head.weight` / embedding tensor that the
+  checkpoint does not have.
+
+- `patch_vllm_vision_split.py` drops the split vision `q_proj` / `k_proj` /
+  `v_proj` name substrings from `Qwen3_VisionTransformer`'s checkpoint
+  name-mapping. turboderp's Qwen3.8-Flash-Next pack ships both the split
+  trellis tensors and the original fused bf16 `attn.qkv.weight/bias`, but
+  vLLM's vision transformer only holds the fused tensor, so
+  `AutoWeightsLoader` raised `no module or parameter named
+  'blocks.0.attn.k_proj'` once the language model had already finished
+  loading. Dropping the split names is correct either way: the fused bf16
+  copy is the one vLLM's module actually uses.
+
+- `patch_vllm_mtp_lmhead.py` is the same `quant_config=` addition as the PLE
+  patch, applied to the MTP draft model's `ParallelLMHead` in `mtp.py`. The
+  draft shares the main checkpoint's `lm_head` weights (the checkpoint name
+  mapper routes `lm_head.` to both), so it needs the same fix or the draft's
+  head fails to load with the same missing-`lm_head.weight` error.
+
+Usage: `python3 patch_vllm_qwen4_ple.py <site-packages/vllm>`, then the other
+two the same way. Safe to run more than once.

--- a/tools/patch_vllm_qwen4_exp/patch_vllm_mtp_lmhead.py
+++ b/tools/patch_vllm_qwen4_exp/patch_vllm_mtp_lmhead.py
@@ -1,0 +1,50 @@
+"""quant_config on the Qwen4Exp MTP draft's ParallelLMHead.
+
+The draft model shares the main checkpoint's lm_head (mapper: ``lm_head.`` names go to the
+MTP too). Its ``ParallelLMHead`` was built without quant_config, so it expected ``lm_head.weight``
+while the pack ships ``lm_head.{trellis,suh,svh,mul1}`` (boot 79). Same one-line change as the
+main model. Backup <file>.orig, idempotent, compile-checked.
+
+usage: python3 patch_vllm_mtp_lmhead.py <site-packages/vllm>
+"""
+import os
+import shutil
+import sys
+
+OLD = """                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+"""
+NEW = """                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=self.quant_config,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+"""
+
+
+def main():
+    path = os.path.join(sys.argv[1], "models", "qwen4_exp", "nvidia", "mtp.py")
+    src = open(path, encoding="utf-8").read()
+    if NEW in src:
+        print(f"already patched: {path}")
+        return 0
+    n = src.count(OLD)
+    if n != 1:
+        print(f"ERROR: anchor found {n} times in {path}")
+        return 1
+    out = src.replace(OLD, NEW)
+    compile(out, path, "exec")
+    backup = path + ".orig"
+    if not os.path.exists(backup):
+        shutil.copyfile(path, backup)
+    open(path, "w", encoding="utf-8").write(out)
+    print(f"patched {path} (backup {backup})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/patch_vllm_qwen4_exp/patch_vllm_qwen4_ple.py
+++ b/tools/patch_vllm_qwen4_exp/patch_vllm_qwen4_ple.py
@@ -1,0 +1,84 @@
+"""Two plumbing lines in vLLM's qwen4_exp so the quant config is consulted for
+lm_head and for the PLE n-gram table.
+
+  nvidia/model.py   ParallelLMHead(...)              gains quant_config=self.quant_config
+  nvidia/ple_layer.py PLEVocabParallelEmbedding(...) gains quant_config=quant_config
+
+Without these vLLM builds both layers unquantized regardless of --quantization,
+so an EXL3 pack whose lm_head / n-gram rows are trellis tensors cannot load.
+Backs up each file to <file>.orig (kept if present), idempotent, compile-checked.
+
+usage: python3 patch_vllm_qwen4_ple.py <site-packages/vllm>
+"""
+import os
+import shutil
+import sys
+
+MODEL_OLD = '''        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+'''
+MODEL_NEW = '''        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=self.quant_config,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+'''
+PLE_OLD = '''        self.ngram_embedding = PLEVocabParallelEmbedding(
+            padded_vocab_size,
+            self.head_dim,
+            params_dtype=params_dtype,
+            padding_size=divisor,
+            prefix=f"{prefix}.ngram_embedding",
+'''
+PLE_NEW = '''        self.ngram_embedding = PLEVocabParallelEmbedding(
+            padded_vocab_size,
+            self.head_dim,
+            params_dtype=params_dtype,
+            padding_size=divisor,
+            quant_config=quant_config,
+            prefix=f"{prefix}.ngram_embedding",
+'''
+
+
+def patch(path: str, old: str, new: str) -> bool:
+    if not os.path.exists(path):
+        print(f"ERROR: {path} not found")
+        return False
+    src = open(path, encoding="utf-8").read()
+    if new in src:
+        print(f"already patched: {path}")
+        return True
+    n = src.count(old)
+    if n != 1:
+        print(f"ERROR: anchor found {n} times in {path} (need 1)")
+        return False
+    out = src.replace(old, new)
+    try:
+        compile(out, path, "exec")
+    except SyntaxError as e:
+        print(f"ERROR: patched source does not compile: {e}")
+        return False
+    backup = path + ".orig"
+    if not os.path.exists(backup):
+        shutil.copyfile(path, backup)
+    open(path, "w", encoding="utf-8").write(out)
+    print(f"patched {path} (backup {backup})")
+    return True
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 1
+    root = os.path.join(sys.argv[1], "models", "qwen4_exp", "nvidia")
+    ok = patch(os.path.join(root, "model.py"), MODEL_OLD, MODEL_NEW)
+    ok = patch(os.path.join(root, "ple_layer.py"), PLE_OLD, PLE_NEW) and ok
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/patch_vllm_qwen4_exp/patch_vllm_vision_split.py
+++ b/tools/patch_vllm_qwen4_exp/patch_vllm_vision_split.py
@@ -1,0 +1,52 @@
+"""Drop the split vision q/k/v tensors an EXL3 pack ships next to the fused bf16 attn.qkv.
+
+turboderp's Qwen3.8-Flash-Next pack stores `visual.blocks.N.attn.{q,k,v}_proj.*` trellis tensors
+AND the original fused `attn.qkv.weight/bias` (bf16). vLLM's Qwen3_VisionTransformer holds only
+`attn.qkv`, so AutoWeightsLoader raised "no module or parameter named 'blocks.0.attn.k_proj'"
+(boot 74, after the whole language model had loaded). The fused bf16 copy is the better source
+anyway. The substrings start with a dot, so `self_attn.q_proj` in the language model is untouched.
+Backup <file>.orig2, idempotent, compile-checked.
+
+usage: python3 patch_vllm_vision_split.py <site-packages/vllm>
+"""
+import os
+import shutil
+import sys
+
+OLD = """            orig_to_new_substr={"mtp.": None},
+            orig_to_new_prefix={"visual.": None} if self.language_model_only else {},
+"""
+NEW = """            orig_to_new_substr={
+                "mtp.": None,
+                # EXL3 packs ship split vision q/k/v trellis tensors next to
+                # the fused bf16 attn.qkv this module holds; drop the split ones.
+                ".attn.q_proj.": None,
+                ".attn.k_proj.": None,
+                ".attn.v_proj.": None,
+            },
+            orig_to_new_prefix={"visual.": None} if self.language_model_only else {},
+"""
+
+
+def main():
+    path = os.path.join(sys.argv[1], "models", "qwen4_exp", "nvidia", "model.py")
+    src = open(path, encoding="utf-8").read()
+    if '".attn.k_proj.": None' in src:
+        print(f"already patched: {path}")
+        return 0
+    n = src.count(OLD)
+    if n != 1:
+        print(f"ERROR: anchor found {n} times in {path}")
+        return 1
+    out = src.replace(OLD, NEW)
+    compile(out, path, "exec")
+    backup = path + ".orig2"
+    if not os.path.exists(backup):
+        shutil.copyfile(path, backup)
+    open(path, "w", encoding="utf-8").write(out)
+    print(f"patched {path} (backup {backup})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/receipts/ab_moe_gb10.json
+++ b/tools/receipts/ab_moe_gb10.json
@@ -1,0 +1,356 @@
+{
+  "gpu": "NVIDIA GB10",
+  "capability": "sm_121",
+  "abi": 2,
+  "exl3_moe_max_concurrency": 6,
+  "shape": {
+    "hidden": 4096,
+    "intermediate": 2048,
+    "num_experts": 288,
+    "top_k": 8
+  },
+  "cases": [
+    {
+      "K": 2,
+      "m": 1,
+      "experts_touched": 8,
+      "exl3_moe": {
+        "median_us": 516.42,
+        "p95_us": 521.15,
+        "min_us": 510.85
+      },
+      "p2b_fused_moe": {
+        "median_us": 305.89,
+        "p95_us": 372.45,
+        "min_us": 296.61
+      },
+      "p2b_launches_per_step": 1,
+      "speedup_p2b_over_exl3_moe": 1.688,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.0022,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00233,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "ref_absmax": 1.049
+    },
+    {
+      "K": 2,
+      "m": 2,
+      "experts_touched": 15,
+      "exl3_moe": {
+        "median_us": 776.96,
+        "p95_us": 943.49,
+        "min_us": 760.0
+      },
+      "p2b_fused_moe": {
+        "median_us": 644.99,
+        "p95_us": 658.18,
+        "min_us": 596.74
+      },
+      "p2b_launches_per_step": 2,
+      "speedup_p2b_over_exl3_moe": 1.205,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.0024,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00253,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "ref_absmax": 1.277
+    },
+    {
+      "K": 2,
+      "m": 4,
+      "experts_touched": 30,
+      "exl3_moe": {
+        "median_us": 1502.26,
+        "p95_us": 1621.41,
+        "min_us": 1258.78
+      },
+      "p2b_fused_moe": {
+        "median_us": 1222.37,
+        "p95_us": 1269.12,
+        "min_us": 1160.0
+      },
+      "p2b_launches_per_step": 4,
+      "speedup_p2b_over_exl3_moe": 1.229,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00277,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.0029,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "ref_absmax": 1.517
+    },
+    {
+      "K": 2,
+      "m": 8,
+      "experts_touched": 62,
+      "exl3_moe": {
+        "median_us": 2501.47,
+        "p95_us": 2956.29,
+        "min_us": 2256.83
+      },
+      "p2b_fused_moe": {
+        "median_us": 2360.51,
+        "p95_us": 2420.8,
+        "min_us": 2318.46
+      },
+      "p2b_launches_per_step": 8,
+      "speedup_p2b_over_exl3_moe": 1.06,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00355,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00336,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "ref_absmax": 1.649
+    },
+    {
+      "K": 3,
+      "m": 1,
+      "experts_touched": 8,
+      "exl3_moe": {
+        "median_us": 577.38,
+        "p95_us": 584.06,
+        "min_us": 569.76
+      },
+      "p2b_fused_moe": {
+        "median_us": 455.23,
+        "p95_us": 462.5,
+        "min_us": 432.16
+      },
+      "p2b_launches_per_step": 1,
+      "speedup_p2b_over_exl3_moe": 1.268,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00244,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00233,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "ref_absmax": 1.154
+    },
+    {
+      "K": 3,
+      "m": 2,
+      "experts_touched": 15,
+      "exl3_moe": {
+        "median_us": 883.31,
+        "p95_us": 893.41,
+        "min_us": 868.67
+      },
+      "p2b_fused_moe": {
+        "median_us": 935.15,
+        "p95_us": 950.18,
+        "min_us": 893.28
+      },
+      "p2b_launches_per_step": 2,
+      "speedup_p2b_over_exl3_moe": 0.945,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00271,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00228,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "ref_absmax": 1.48
+    },
+    {
+      "K": 3,
+      "m": 4,
+      "experts_touched": 30,
+      "exl3_moe": {
+        "median_us": 1733.65,
+        "p95_us": 1854.46,
+        "min_us": 1450.14
+      },
+      "p2b_fused_moe": {
+        "median_us": 1815.73,
+        "p95_us": 1834.88,
+        "min_us": 1761.54
+      },
+      "p2b_launches_per_step": 4,
+      "speedup_p2b_over_exl3_moe": 0.955,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00279,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00315,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "ref_absmax": 1.588
+    },
+    {
+      "K": 3,
+      "m": 8,
+      "experts_touched": 62,
+      "exl3_moe": {
+        "median_us": 2914.77,
+        "p95_us": 3279.74,
+        "min_us": 2637.73
+      },
+      "p2b_fused_moe": {
+        "median_us": 3564.34,
+        "p95_us": 3922.14,
+        "min_us": 3507.1
+      },
+      "p2b_launches_per_step": 8,
+      "speedup_p2b_over_exl3_moe": 0.818,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00363,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00367,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "ref_absmax": 1.703
+    },
+    {
+      "K": 4,
+      "m": 1,
+      "experts_touched": 8,
+      "exl3_moe": {
+        "median_us": 611.31,
+        "p95_us": 694.21,
+        "min_us": 600.16
+      },
+      "p2b_fused_moe": {
+        "median_us": 479.63,
+        "p95_us": 536.16,
+        "min_us": 437.86
+      },
+      "p2b_launches_per_step": 1,
+      "speedup_p2b_over_exl3_moe": 1.275,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00234,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00264,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "ref_absmax": 1.15
+    },
+    {
+      "K": 4,
+      "m": 2,
+      "experts_touched": 15,
+      "exl3_moe": {
+        "median_us": 976.88,
+        "p95_us": 995.3,
+        "min_us": 945.63
+      },
+      "p2b_fused_moe": {
+        "median_us": 976.13,
+        "p95_us": 996.93,
+        "min_us": 928.22
+      },
+      "p2b_launches_per_step": 2,
+      "speedup_p2b_over_exl3_moe": 1.001,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00258,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00239,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "ref_absmax": 1.35
+    },
+    {
+      "K": 4,
+      "m": 4,
+      "experts_touched": 30,
+      "exl3_moe": {
+        "median_us": 1924.32,
+        "p95_us": 2376.7,
+        "min_us": 1612.58
+      },
+      "p2b_fused_moe": {
+        "median_us": 1908.5,
+        "p95_us": 1965.28,
+        "min_us": 1840.42
+      },
+      "p2b_launches_per_step": 4,
+      "speedup_p2b_over_exl3_moe": 1.008,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.0034,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00306,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "ref_absmax": 1.63
+    },
+    {
+      "K": 4,
+      "m": 8,
+      "experts_touched": 62,
+      "exl3_moe": {
+        "median_us": 3308.0,
+        "p95_us": 3636.45,
+        "min_us": 3055.01
+      },
+      "p2b_fused_moe": {
+        "median_us": 3728.83,
+        "p95_us": 3983.52,
+        "min_us": 3646.4
+      },
+      "p2b_launches_per_step": 8,
+      "speedup_p2b_over_exl3_moe": 0.887,
+      "exl3_moe_acc": {
+        "max_abs_err": 0.00322,
+        "min_cos": 0.999999,
+        "finite": true
+      },
+      "p2b_acc": {
+        "max_abs_err": 0.00307,
+        "min_cos": 0.999998,
+        "finite": true
+      },
+      "ref_absmax": 1.786
+    }
+  ],
+  "summary": {
+    "cases": 12,
+    "p2b_faster_in": 8,
+    "best": 1.688,
+    "worst": 0.818
+  }
+}

--- a/tools/verify_native_pack/README.md
+++ b/tools/verify_native_pack/README.md
@@ -1,0 +1,39 @@
+# tools/verify_native_pack
+
+Four GPU smoke tests against a real pack directory, meant to run before
+starting a full vLLM server so a bad pack or a broken kernel change fails in
+seconds instead of after a multi-minute boot. Each takes `<pack_dir>` as its
+only argument and needs `vllm`, `vllm_exl3`, `exllamav3_ext`, and a GPU; none
+of them start a server.
+
+- `test_ngram_embedding.py` is the correctness gate for
+  `Exl3EmbeddingMethod`. It decodes real packed rows (random shard blocks
+  plus rows straddling every head boundary) three ways -- the
+  `exllamav3_ext.ngram_dequant` kernel, the plugin's pure-torch fallback, and
+  (if importable) exllamav3's own decoder -- and requires all three to agree;
+  checks the plugin's mul1 codebook against exllamav3's; runs the embedding
+  method end to end on a fake table (shard params aliasing, name-based
+  loading, 2-D id lookups, ext/torch agreement, CUDA graph capture); and
+  checks vLLM's regenerated hash layout and the rewritten
+  `quantization_config` both resolve correctly. Prints `NGRAM_TEST: PASS`
+  only if every check passes.
+
+- `mul1_check.py` is pre-boot sanity for mul1-coded packs: it confirms the
+  packed marker tensor equals the plugin's `MUL1_MARKER_SIGNED_INT32`
+  constant, and that `LinearEXL3` actually forwards differently when built
+  with a mul1 marker versus an mcg marker -- i.e. that the two codebooks are
+  wired to distinct code paths, not silently interchangeable.
+
+- `pad_check.py` is pre-boot sanity for padded EXL3 linears (matrices padded
+  to a multiple of 128): it checks that a padded layer's extra output
+  columns are exactly zero (`svh` is zero there) and that a padded layer
+  accepts zero-extended input without changing the unpadded part of the
+  result.
+
+- `compile_check.py` checks that the EXL3 custom ops register with
+  `torch.ops.vllm`, run eagerly, and trace under
+  `torch.compile(fullgraph=True)` for both a padded dense linear and the
+  n-gram lookup, since a custom op that only works eagerly breaks the
+  moment vLLM compiles the model.
+
+Usage: `python3 <script>.py <pack_dir>` for each.

--- a/tools/verify_native_pack/compile_check.py
+++ b/tools/verify_native_pack/compile_check.py
@@ -1,0 +1,104 @@
+"""Pre-boot check: the EXL3 custom ops register, run eagerly, and trace under
+torch.compile(fullgraph=True) for both a padded dense linear and the n-gram lookup."""
+import glob
+import json
+import struct
+import sys
+
+import torch
+from safetensors import safe_open
+
+import exllamav3_ext  # noqa: F401
+from vllm_exl3 import exl3 as X
+
+pack = sys.argv[1]
+ok = True
+print("ops ready:", X._EXL3_OPS_READY, "| ops present:", hasattr(torch.ops.vllm, "exl3_linear_forward"), hasattr(torch.ops.vllm, "exl3_ngram_lookup"))
+ok &= X._EXL3_OPS_READY
+
+# --- dense linear (vision fc1, padded 1152 -> 4304 stored as 4352) --------------------------
+names = {}
+for fn in sorted(glob.glob(pack + "/model-*.safetensors")):
+    with open(fn, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        h = json.loads(f.read(n))
+    for k in h:
+        if k.startswith("model.visual.blocks.0.mlp.linear_fc1."):
+            names[k] = fn
+
+
+def get(k):
+    with safe_open(names[k], "pt", device="cuda") as f:
+        return f.get_tensor(k)
+
+
+p = "model.visual.blocks.0.mlp.linear_fc1."
+lin = X.make_linear_exl3(get(p + "trellis"), get(p + "suh"), get(p + "svh"), None, get(p + "mul1").reshape(1))
+cfg = X.Exl3Config(bits=3, codebook="mul1", scope="native_all_linears")
+layer = torch.nn.Module()
+layer.prefix = "visual.blocks.0.mlp.linear_fc1"
+layer.quant_method = X.Exl3LinearMethod(cfg, bits=5)
+layer._exl3_linears = [lin]
+layer._exl3_linear_n_shards = 1
+layer._exl3_linear_output_partition_sizes = [4352]
+layer._exl3_linear_true_out = [4304]
+layer._exl3_linear_true_in = 1152
+layer._exl3_linear_padded = True
+layer._exl3_linear_input_size_per_partition = 1152
+layer._exl3_linear_bf16_shards = []
+layer._exl3_opaque_name = X._exl3_register_opaque_layer(layer, "linear")
+print("linear op name:", layer._exl3_opaque_name)
+x = torch.randn(6, 1152, device="cuda", dtype=torch.bfloat16)
+bias = get(p + "bias")[:4304].to(torch.bfloat16)
+y_eager = layer.quant_method._apply_impl(layer, x) + bias
+y_op = layer.quant_method.apply(layer, x, bias)
+print("linear eager vs op:", tuple(y_op.shape), y_op.dtype, "equal:", torch.equal(y_eager, y_op))
+ok &= torch.equal(y_eager, y_op) and tuple(y_op.shape) == (6, 4304)
+
+
+def f_lin(t):
+    return layer.quant_method.apply(layer, t, bias)
+
+
+y_c = torch.compile(f_lin, fullgraph=True)(x)
+print("linear under torch.compile(fullgraph=True):", tuple(y_c.shape), "equal to eager:", torch.equal(y_c, y_eager))
+ok &= torch.equal(y_c, y_eager)
+
+# --- n-gram lookup on a small fake table ---------------------------------------------------
+PFX = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding."
+with safe_open(pack + "/ngram_embedding.safetensors", "pt") as f:
+    head_bias = f.get_tensor(PFX + "head_bias")
+    rows = f.get_slice(PFX + "shard_0.trellis")[0:2048]
+ncfg = X.Exl3Config(bits=3, codebook="mul1", scope="native_all_linears",
+                    ngram_embedding={"bits": 5, "num_shards": 2, "rows_per_shard": 1024, "num_heads": 16, "modules": ["ngram_embedding"]})
+spec = ncfg._ngram_embedding_spec("model.layers.1.ple.ple_embedding.ngram_embedding")
+m = X.Exl3EmbeddingMethod(ncfg, spec)
+emb = torch.nn.Module()
+emb.tp_rank, emb.tp_size = 0, 1
+emb._exl3_prefix = "model.layers.1.ple.ple_embedding.ngram_embedding"
+emb.quant_method = m
+with torch.device("cuda"):
+    m.create_weights(emb, 160, [2048], 160, 2048, torch.bfloat16)
+params = dict(emb.named_parameters())
+for i in range(2):
+    params[f"shard_{i}.trellis"].weight_loader(params[f"shard_{i}.trellis"], rows[i * 1024:(i + 1) * 1024])
+for name, val in (("head_bias", head_bias), ("head_offsets", torch.arange(16, dtype=torch.int64) * 128),
+                  ("head_vocab_sizes", torch.full((16,), 128, dtype=torch.int64)), ("layer_multipliers", torch.tensor([1, 2, 3]))):
+    params[name].weight_loader(params[name], val)
+m.process_weights_after_loading(emb)
+print("ngram op name:", emb._exl3_opaque_name)
+ids = torch.randint(0, 2048, (5, 16), device="cuda")
+e_eager = m._embedding_impl(emb, ids)
+e_op = m.embedding(emb, ids)
+print("ngram eager vs op:", tuple(e_op.shape), e_op.dtype, "equal:", torch.equal(e_eager, e_op))
+ok &= torch.equal(e_eager, e_op)
+
+
+def f_emb(t):
+    return m.embedding(emb, t)
+
+
+e_c = torch.compile(f_emb, fullgraph=True)(ids)
+print("ngram under torch.compile(fullgraph=True):", tuple(e_c.shape), "equal:", torch.equal(e_c, e_eager))
+ok &= torch.equal(e_c, e_eager)
+print("COMPILE_CHECK:", "PASS" if ok else "FAIL")

--- a/tools/verify_native_pack/mul1_check.py
+++ b/tools/verify_native_pack/mul1_check.py
@@ -1,0 +1,38 @@
+"""Pre-boot sanity for mul1 packs through the plugin's LinearEXL3 path and MoE marker validator."""
+import sys
+
+import torch
+from safetensors import safe_open
+
+import exllamav3_ext  # noqa: F401  (needs torch imported first)
+from vllm_exl3 import exl3 as X
+
+pack = sys.argv[1]
+P = "model.language_model.layers.0.mlp.shared_expert.gate_proj."
+with safe_open(pack + "/model-00001-of-00007.safetensors", "pt", device="cuda") as f:
+    tr, suh, svh, mul1 = (f.get_tensor(P + s) for s in ("trellis", "suh", "svh", "mul1"))
+ok = True
+print("marker", int(mul1), "== MUL1_MARKER:", int(mul1) == X.MUL1_MARKER_SIGNED_INT32, "trellis", tuple(tr.shape))
+ok &= int(mul1) == X.MUL1_MARKER_SIGNED_INT32
+lin = X.make_linear_exl3(tr, suh, svh, None, mul1.reshape(1))
+print("LinearEXL3 attrs: mcg=", getattr(lin, "mcg", "n/a"), "mul1=", getattr(lin, "mul1", "n/a"))
+x = torch.randn(8, 2560, device="cuda", dtype=torch.float16)
+y = lin.forward(x, {}, out_dtype=torch.float32)
+lin2 = X.make_linear_exl3(
+    tr, suh, svh, torch.tensor([X.MCG_MARKER_SIGNED_INT32], dtype=torch.int32, device="cuda"), None
+)
+y2 = lin2.forward(x, {}, out_dtype=torch.float32)
+differs = not torch.allclose(y, y2)
+print("mul1 forward finite:", y.isfinite().all().item(), "mean|y|=%.4f" % y.abs().mean().item(), "differs from MCG decode:", differs)
+ok &= bool(y.isfinite().all().item()) and differs
+m = torch.zeros(4, 2, 1, dtype=torch.int32)
+u = torch.full((4, 2, 1), X.MUL1_MARKER_SIGNED_INT32, dtype=torch.int32)
+X._check_moe_codebook_markers(m, u, "w13")
+print("validator: all-mul1 ok")
+try:
+    X._check_moe_codebook_markers(m, torch.zeros_like(u), "w13")
+    ok = False
+    print("validator FAILED to reject missing markers")
+except RuntimeError as e:
+    print("validator rejects missing markers:", str(e)[:70])
+print("MUL1_CHECK:", "PASS" if ok else "FAIL")

--- a/tools/verify_native_pack/pad_check.py
+++ b/tools/verify_native_pack/pad_check.py
@@ -1,0 +1,53 @@
+"""Pre-boot sanity for padded EXL3 linears: the padded output columns of the vision fc1 are
+exactly zero (svh = 0 there), fc2 accepts zero-extended inputs, and the patched plugin exposes
+the padding helpers and codebook-flag plumbing."""
+import glob
+import json
+import struct
+import sys
+
+import torch
+from safetensors import safe_open
+
+import exllamav3_ext  # noqa: F401
+from vllm_exl3 import exl3 as X
+
+pack = sys.argv[1]
+ok = True
+names = {}
+for fn in sorted(glob.glob(pack + "/model-*.safetensors")):
+    with open(fn, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        h = json.loads(f.read(n))
+    for k in h:
+        if k.startswith("model.visual.blocks.0.mlp."):
+            names[k] = fn
+
+
+def get(k):
+    with safe_open(names[k], "pt", device="cuda") as f:
+        return f.get_tensor(k)
+
+
+p = "model.visual.blocks.0.mlp."
+fc1 = X.make_linear_exl3(get(p + "linear_fc1.trellis"), get(p + "linear_fc1.suh"), get(p + "linear_fc1.svh"), None, get(p + "linear_fc1.mul1").reshape(1))
+fc2 = X.make_linear_exl3(get(p + "linear_fc2.trellis"), get(p + "linear_fc2.suh"), get(p + "linear_fc2.svh"), None, get(p + "linear_fc2.mul1").reshape(1))
+print("fc1 in/out:", fc1.in_features, fc1.out_features, "| fc2 in/out:", fc2.in_features, fc2.out_features)
+x = torch.randn(8, 1152, device="cuda", dtype=torch.float16)
+y1 = fc1.forward(x, {}, out_dtype=torch.float32)
+tail_max = y1[:, 4304:].abs().max().item()
+print("fc1 out", tuple(y1.shape), "padded columns max |y| =", tail_max, "| real columns mean |y| = %.4f" % y1[:, :4304].abs().mean().item())
+ok &= tuple(y1.shape) == (8, 4352) and tail_max == 0.0 and bool(y1.isfinite().all())
+h = torch.nn.functional.gelu(y1[:, :4304]).to(torch.float16)
+h_pad = torch.nn.functional.pad(h, (0, 48))
+y2 = fc2.forward(h_pad.contiguous(), {}, out_dtype=torch.float32)
+print("fc2 out", tuple(y2.shape), "finite:", bool(y2.isfinite().all()), "mean |y| = %.4f" % y2.abs().mean().item())
+ok &= tuple(y2.shape) == (8, 1152) and bool(y2.isfinite().all())
+# padded input rows must not matter: garbage in the padded input columns must change nothing
+h_junk = h_pad.clone()
+h_junk[:, 4304:] = 0.0
+y2b = fc2.forward(h_junk.contiguous(), {}, out_dtype=torch.float32)
+print("fc2 identical with zero padding rows:", torch.equal(y2, y2b))
+print("plugin helpers:", hasattr(X, "_exl3_pad128") and X._exl3_pad128(4304) == 4352, "| flags plumbing:", "_exl3_codebook_flags" in open(X.__file__).read())
+ok &= hasattr(X, "_exl3_pad128") and "_exl3_codebook_flags" in open(X.__file__).read()
+print("PAD_CHECK:", "PASS" if ok else "FAIL")

--- a/tools/verify_native_pack/test_ngram_embedding.py
+++ b/tools/verify_native_pack/test_ngram_embedding.py
@@ -20,7 +20,9 @@ import time
 
 import torch
 
-PACK = sys.argv[1] if len(sys.argv) > 1 else "/home/markus/models/Qwen3.8-Flash-Next-exl3-3.05bpw"
+if len(sys.argv) < 2:
+    sys.exit("usage: test_ngram_embedding.py <pack_dir>")
+PACK = sys.argv[1]
 PFX = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding."
 K = 5
 ROWS_PER_SHARD = 2500012

--- a/tools/verify_native_pack/test_ngram_embedding.py
+++ b/tools/verify_native_pack/test_ngram_embedding.py
@@ -1,0 +1,190 @@
+"""Correctness gate for Exl3EmbeddingMethod before any Qwen boot (GPU, no server).
+
+1. Decoder: real packed rows from the pack (random shard blocks plus rows straddling
+   every head boundary) decoded by exllamav3_ext.ngram_dequant, by the plugin's torch
+   twin, and (if importable) by exllamav3's own ngram_codec.dequant_rows; all must agree.
+2. Codebook: plugin's ngram_mul1_codebook vs exllamav3's mul1_codebook (if importable).
+3. Method end to end on a fake 4 x 1024-row table filled with those real rows: shard
+   params alias one table, loaders land by name, 2-D ids come back as [.., 160] in the
+   layer dtype, ext and torch kernels agree, and the lookup captures into a CUDA graph.
+4. vLLM's regenerated hash layout for ple_dense_layer_id 0 equals the checkpoint's.
+5. The rewritten quantization_config resolves: n-gram spec for the ple prefix, K=5 lm_head.
+
+Prints NGRAM_TEST: PASS only when every check passes.
+usage: python3 test_ngram_embedding.py <pack_dir>
+"""
+import json
+import os
+import sys
+import time
+
+import torch
+
+PACK = sys.argv[1] if len(sys.argv) > 1 else "/home/markus/models/Qwen3.8-Flash-Next-exl3-3.05bpw"
+PFX = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding."
+K = 5
+ROWS_PER_SHARD = 2500012
+NUM_SHARDS = 128
+FAKE_SHARDS, FAKE_ROWS = 4, 1024
+failures = []
+
+
+def check(cond, msg):
+    print(("  ok   " if cond else "  FAIL ") + msg)
+    if not cond:
+        failures.append(msg)
+
+
+t0 = time.time()
+dev = torch.device("cuda")
+from safetensors import safe_open
+import exllamav3_ext as ext
+from vllm_exl3 import exl3 as X
+
+print(f"plugin {X.__file__}")
+check(hasattr(X, "Exl3EmbeddingMethod"), "plugin exposes Exl3EmbeddingMethod")
+check(hasattr(ext, "ngram_dequant"), "exllamav3_ext has ngram_dequant")
+
+# ---- 1. gather real rows -------------------------------------------------------
+with safe_open(os.path.join(PACK, "ngram_embedding.safetensors"), "pt") as f:
+    head_bias = f.get_tensor(PFX + "head_bias")
+    head_offsets = f.get_tensor(PFX + "head_offsets")
+    head_sizes = f.get_tensor(PFX + "head_vocab_sizes")
+    layer_mult = f.get_tensor(PFX + "layer_multipliers")
+    total = int(head_offsets[-1] + head_sizes[-1])
+    g = torch.Generator().manual_seed(1234)
+    ids = []
+    blocks = []
+    # rows straddling every head boundary (4 before, 4 after), then random 64-row blocks
+    for h in range(1, 16):
+        b = int(head_offsets[h])
+        blocks.append((b - 4, 8))
+    n_random = (FAKE_SHARDS * FAKE_ROWS - sum(n for _, n in blocks)) // 64
+    for _ in range(n_random):
+        start = int(torch.randint(0, total - 64, (1,), generator=g))
+        if start % ROWS_PER_SHARD + 64 > ROWS_PER_SHARD:  # keep a block inside one shard
+            start -= 64
+        blocks.append((start, 64))
+    rows = []
+    for start, n in blocks:
+        s, r = divmod(start, ROWS_PER_SHARD)
+        assert r + n <= ROWS_PER_SHARD
+        rows.append(f.get_slice(f"{PFX}shard_{s}.trellis")[r : r + n])
+        ids.extend(range(start, start + n))
+packed = torch.cat(rows, 0)
+ids = torch.tensor(ids, dtype=torch.int64)
+check(packed.shape[1] == 1 + 160 * K // 16 and packed.dtype == torch.int16,
+      f"packed rows are int16 [{packed.shape[0]}, {packed.shape[1]}] (K={K})")
+check(total == 320001446 and int(head_sizes.sum()) == total, f"checkpoint head layout sums to {total}")
+pad = FAKE_SHARDS * FAKE_ROWS - packed.shape[0]
+if pad:
+    packed = torch.cat([packed, packed[:pad]], 0)
+    ids = torch.cat([ids, ids[:pad]], 0)
+heads = (torch.searchsorted(head_offsets, ids, right=True) - 1).clamp(0, 15)
+print(f"  rows={packed.shape[0]} heads used={sorted(set(heads.tolist()))} read {time.time()-t0:.1f}s")
+
+packed_d, heads_d, bias_d = packed.to(dev), heads.to(torch.int32).to(dev), head_bias.to(dev)
+out_ext = torch.empty(packed.shape[0], 160, dtype=torch.float16, device=dev)
+ext.ngram_dequant(packed_d.contiguous(), K, heads_d.contiguous(), bias_d.contiguous(), out_ext)
+out_torch = X.ngram_dequant_rows_torch(packed_d, K, heads_d, bias_d)
+diff = (out_ext.float() - out_torch.float()).abs()
+check(torch.equal(out_ext, out_torch), f"ext == torch twin (max abs diff {diff.max().item():.3e}, mismatches {(diff > 0).sum().item()})")
+check(out_ext.isfinite().all().item() and out_ext.abs().max().item() > 0, f"decoded rows finite and non-zero (|max| {out_ext.abs().max().item():.3f})")
+try:
+    from exllamav3.modules.quant.exl3_lib import ngram_codec as NC
+    cb_ref = NC.mul1_codebook(dev)
+    cb_mine = X.ngram_mul1_codebook(dev)
+    check(torch.equal(cb_ref.to(torch.float16), cb_mine), f"codebook == exllamav3 mul1_codebook (mismatches {(cb_ref.to(torch.float16) != cb_mine).sum().item()})")
+    ref = NC.dequant_rows(packed_d, K, cb_ref, bias_d.float()[heads_d.long()]).to(torch.float16)
+    d2 = (ref.float() - out_ext.float()).abs()
+    check(torch.equal(ref, out_ext), f"ext == exllamav3 dequant_rows (max abs diff {d2.max().item():.3e}, mismatches {(d2 > 0).sum().item()})")
+except Exception as e:  # noqa: BLE001
+    print(f"  skip exllamav3 ngram_codec reference: {type(e).__name__}: {str(e)[:100]}")
+
+# ---- 3. method end to end on a fake table ----------------------------------------
+cfg = X.Exl3Config(bits=3, codebook="mul1", scope="native_all_linears",
+                   ngram_embedding={"bits": K, "num_shards": FAKE_SHARDS, "rows_per_shard": FAKE_ROWS,
+                                    "num_heads": 16, "modules": ["ngram_embedding"]})
+spec = cfg._ngram_embedding_spec("model.layers.1.ple.ple_embedding.ngram_embedding")
+check(spec is not None and cfg._ngram_embedding_spec("model.layers.1.ple.kv_proj") is None, "spec matches the table prefix only")
+method = X.Exl3EmbeddingMethod(cfg, spec)
+layer = torch.nn.Module()
+layer.tp_rank, layer.tp_size = 0, 1
+with torch.device(dev):
+    method.create_weights(layer, 160, [FAKE_SHARDS * FAKE_ROWS], 160, FAKE_SHARDS * FAKE_ROWS, torch.bfloat16)
+table = layer._exl3_ngram_table
+check(table.device.type == "cuda" and table.dtype == torch.int16, f"table on {table.device} {table.dtype} {tuple(table.shape)}")
+names = dict(layer.named_parameters())
+check(all(f"shard_{i}.trellis" in names for i in range(FAKE_SHARDS)) and {"head_bias", "head_offsets", "head_vocab_sizes", "layer_multipliers"} <= set(names),
+      f"named_parameters has shard_i.trellis and aux ({len(names)} params)")
+check(all(names[f"shard_{i}.trellis"].data_ptr() == table[i].data_ptr() for i in range(FAKE_SHARDS)), "shard params alias the table (no second copy)")
+for i in range(FAKE_SHARDS):
+    p = names[f"shard_{i}.trellis"]
+    p.weight_loader(p, packed[i * FAKE_ROWS : (i + 1) * FAKE_ROWS])
+fake_offsets = torch.arange(16, dtype=torch.int64) * (FAKE_SHARDS * FAKE_ROWS // 16)
+fake_sizes = torch.full((16,), FAKE_SHARDS * FAKE_ROWS // 16, dtype=torch.int64)
+for name, val in (("head_bias", head_bias), ("head_offsets", fake_offsets), ("head_vocab_sizes", fake_sizes), ("layer_multipliers", layer_mult)):
+    names[name].weight_loader(names[name], val)
+bad = False
+try:
+    p = names["shard_0.trellis"]
+    p.weight_loader(p, torch.zeros(FAKE_ROWS, 31, dtype=torch.int16))
+except ValueError:
+    bad = True
+check(bad, "loader rejects a shard with the wrong K/words")
+method.process_weights_after_loading(layer)
+check(method.kernel == "ext" and method._ext is not None, f"kernel resolved: {method.kernel}")
+check(torch.equal(layer._exl3_ngram_rows.cpu(), packed), "table content equals the loaded rows")
+gen = torch.Generator(device="cpu").manual_seed(7)
+q_ids = torch.randint(0, FAKE_SHARDS * FAKE_ROWS, (37, 16), generator=gen).to(dev)
+out = method.embedding(layer, q_ids)
+check(tuple(out.shape) == (37, 16, 160) and out.dtype == torch.bfloat16, f"embedding output {tuple(out.shape)} {out.dtype}")
+flat = q_ids.reshape(-1)
+ref_heads = (flat // (FAKE_SHARDS * FAKE_ROWS // 16)).to(torch.int32)
+ref = X.ngram_dequant_rows_torch(packed_d[flat], K, ref_heads, bias_d).to(torch.bfloat16).view(37, 16, 160)
+check(torch.equal(out, ref), "embedding() == torch reference on the same rows/heads")
+method.kernel = "torch"
+out2 = method.embedding(layer, q_ids)
+method.kernel = "ext"
+check(torch.equal(out, out2), "VLLM_EXL3_NGRAM_KERNEL=torch path == ext path")
+# CUDA graph capture of the lookup (no host sync allowed on this path)
+static_ids = q_ids.clone()
+s = torch.cuda.Stream()
+s.wait_stream(torch.cuda.current_stream())
+with torch.cuda.stream(s):
+    for _ in range(3):
+        method.embedding(layer, static_ids)
+torch.cuda.current_stream().wait_stream(s)
+graph = torch.cuda.CUDAGraph()
+with torch.cuda.graph(graph):
+    static_out = method.embedding(layer, static_ids)
+graph.replay()
+torch.cuda.synchronize()
+check(torch.equal(static_out, out), "lookup captured and replayed in a CUDA graph with identical output")
+static_ids.copy_(torch.randint(0, FAKE_SHARDS * FAKE_ROWS, (37, 16), generator=gen).to(dev))
+graph.replay()
+torch.cuda.synchronize()
+check(torch.equal(static_out, method.embedding(layer, static_ids)), "graph replay tracks new ids")
+
+# ---- 4. vLLM hash layout for ple_dense_layer_id 0 ----------------------------------
+try:
+    from vllm.models.qwen4_exp.nvidia.ple_layer import Qwen4ExpNGramEmbedding as NG
+    sizes, offs, tot = NG._make_vocab_layout(ngram_vocab_size_base=20000000, ngram_heads=16, ple_dense_layer_id=0)
+    mult = NG._make_layer_multipliers(ngram_size=3, unigram_vocab_size=248320, seed=1234, ple_dense_layer_id=0)
+    check(sizes == head_sizes.tolist() and offs == head_offsets.tolist() and tot == total, "vLLM head layout (id 0) == checkpoint")
+    check(mult == layer_mult.tolist(), "vLLM layer multipliers (id 0) == checkpoint")
+except Exception as e:  # noqa: BLE001
+    check(False, f"vLLM layout check raised {type(e).__name__}: {str(e)[:120]}")
+
+# ---- 5. the rewritten config resolves ------------------------------------------------
+qc = json.load(open(os.path.join(PACK, "config.json")))
+qc = (qc.get("text_config") or {}).get("quantization_config") or qc.get("quantization_config")
+c2 = X.Exl3Config.from_config(dict(qc))
+sp = c2._ngram_embedding_spec("model.layers.1.ple.ple_embedding.ngram_embedding")
+check(sp is not None and sp["bits"] == K and sp["num_shards"] == NUM_SHARDS and sp["rows_per_shard"] == ROWS_PER_SHARD and sp["num_heads"] == 16,
+      f"config ngram spec: {sp}")
+check(c2._matches_non_routed_exl3("lm_head") and c2._bits_for_non_routed("lm_head") == 5, "config lm_head -> K5 trellis linear")
+check(not any(".shard_" in k for k in (c2.non_routed_exl3.get("layers") or {})), "no n-gram shard prefixes leaked into the dense map")
+
+print(f"elapsed {time.time()-t0:.1f}s")
+print("NGRAM_TEST: " + ("PASS" if not failures else f"FAIL ({len(failures)}): " + "; ".join(failures)[:600]))


### PR DESCRIPTION
## Summary

Extends the EXL3 quant config beyond GLM-5.3's routed-expert-only scope so
this plugin can serve packs quantized directly by turboderp's own ExLlamaV3
tooling ("native" packs) -- validated end to end on
[turboderp/Qwen3.8-Flash-Next-exl3](https://huggingface.co/turboderp/Qwen3.8-Flash-Next-exl3)
(revision `3.05bpw_h5_ng5`).

- **`src/vllm_exl3/exl3.py`**: dense linears (`non_routed_exl3`), `lm_head`
  (`ParallelLMHead`) and row-wise n-gram embedding tables
  (`ngram_embedding`, a new `Exl3EmbeddingMethod`), `mul1` codebook support
  alongside `mcg` (including for routed experts), matrices padded to
  multiples of 128, tuple/`None` shard-id spans in the dense weight loader,
  a per-expert `load_weights` path for routed-experts layers, codebook
  flags threaded through the fused `exl3_moe` launch, and EXL3 custom ops
  registered so they trace opaquely under `torch.compile(fullgraph=True)`.
  Also restores two fixes validated in serving but not yet on `main`: a
  CUDA-graph-safe fat-expert-sync guard, and an MTP/draft-expert
  quant-method delegate that prefers MXFP4 before falling back to the
  non-routed delegate.
- **`tools/patch_vllm_qwen4_exp/`**: three small vLLM patches so
  `Qwen4ExpForConditionalGeneration` passes `quant_config=` to `lm_head`
  and the PLE n-gram table, and drops split vision q/k/v names vLLM's
  fused `attn.qkv` doesn't use.
- **`tools/exl3_pack_tools/`**: scan a native pack's safetensors headers,
  rewrite `config.json`'s `quantization_config` into this plugin's
  `layer_bits` / `non_routed_exl3.layers` / `ngram_embedding` vocabulary,
  and regenerate `model.safetensors.index.json` from the files on disk
  (`regenerate_safetensors_index.py`).
- **`tools/verify_native_pack/`**: four GPU smoke tests (n-gram decode
  parity, mul1/mcg codebook wiring, padded-linear zero columns,
  `torch.compile` op tracing) that catch a bad pack or kernel change in
  seconds instead of after a multi-minute server boot.
- **Docs/notices**: README config-contract and architecture-table updates,
  a new "Native ExLlamaV3 packs" section with preliminary numbers,
  CHANGELOG entries, and THIRD_PARTY_NOTICES.md/NOTICE/ACKNOWLEDGMENTS.md
  attribution for ExLlamaV3's n-gram codec and vLLM's routed-experts
  loader/custom-op registration.
- Version bumped to `0.4.0`.

## Validation

- Compiles and imports cleanly (`Exl3EmbeddingMethod` present,
  `_EXL3_OPS_READY` true).
- Qwen3.8-Flash-Next boots and serves on one DGX Spark GB10 (128 GB),
  32768 context, `--gpu-memory-utilization 0.80`: no-draft decode
  27.2-28.0 tok/s (TTFT 0.185 s at 128 tokens), MTP k=1 decode
  33.8-36.4 tok/s (mean acceptance 1.86 of 2), ~13 min to ready, 78.6 GiB
  on device, 385,570-token KV cache.
- DeepSeek-V4-Flash regression: unaffected (the two restored fixes are the
  only behavioral change outside the new opt-in code paths, and both were
  already validated in serving).
- GPU pack gates (`tools/verify_native_pack/`): n-gram decode/codebook
  parity, mul1/mcg marker wiring, padded-linear zero columns, and
  `torch.compile` op tracing all pass against the validation pack.
- `pytest tests/test_native_pack_unit.py`: 6 passed (CPU-only).
- `pytest tests/test_delegation_and_ci.py tests/test_speculative_scheduler.py
  tests/test_routing_parity.py tests/test_attribution_and_sanitization.py`:
  140 passed (CPU-only, unaffected by this change).

## Attribution

- `ngram_dequant_rows_torch` / `ngram_mul1_codebook` reimplement ExLlamaV3's
  `ngram_codec.py` row layout and mul1 codebook arithmetic as a torch
  fallback; the serving path calls ExLlamaV3's own `ngram_dequant` kernel.
  Copyright (c) 2025 Turboderp, MIT -- see THIRD_PARTY_NOTICES.md.
- `_exl3_routed_experts_loader` mirrors the checkpoint-name resolution of
  vLLM's `RoutedExperts.load_weights`; custom ops are registered through
  vLLM's `direct_register_custom_op`. vllm-project/vllm, Apache-2.0.
- Thank you to turboderp for the Qwen3.8-Flash-Next-exl3 pack used to
  validate this release.

## Test plan

- [x] `python3 -c "compile(open('src/vllm_exl3/exl3.py').read(),'x','exec')"`
- [x] Module import check (`Exl3EmbeddingMethod`, `_EXL3_OPS_READY`)
- [x] `pytest tests/test_native_pack_unit.py -q` (6 passed)
- [x] `pytest tests/test_delegation_and_ci.py tests/test_speculative_scheduler.py tests/test_routing_parity.py tests/test_attribution_and_sanitization.py -q` (140 passed)
- [x] GPU gates in `tools/verify_native_pack/` against the validation pack
- [x] Qwen3.8-Flash-Next boots and serves with and without MTP draft
