### PR TITLE
fix(moe): contiguous temporaries in the distinct-suh fat-expert branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fat-expert prefill path (`apply_exl3_batched_fat`, experts with more than `VLLM_EXL3_FAT_THRESHOLD` routed rows in a chunk): the branch for packs whose gate and up projections carry distinct `suh` rotations handed column slices of the shared `gate_up` scratch buffer to `ext.hgemm` and `ext.had_r_128`. Those kernels index contiguous row-major operands, so the expert output was uncorrelated with the reference (relative error 1.3, cosine 0.01 on a Qwen3.8-Flash-Next expert) while short prompts, which never reach that path, looked normal. Prompt log-likelihood over a 6000-token corpus was mean NLL 4.21 through vLLM against 0.94 through exllamav3 on the same pack; with the fix it is 0.943. The branch now runs on contiguous fp32 temporaries. Packs with a shared gate/up `suh` (fused gate_up quantization) were not affected. Regression test: `tests/test_fat_distinct_suh.py`.
+
 - Native fused-MoE decode-row cap measured on GB10 (K2: 8 rows, K3/K4: 1) ships as an opt-in
   (`VLLM_EXL3_NATIVE_MOE_MEASURED_CAP=1`, or `VLLM_EXL3_NATIVE_MOE_MAX_ROWS=<n>`); the default keeps
   the dispatch contract of up to 8 rows. Receipt: `tools/receipts/ab_moe_gb10.json`.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ model's `max_position_embeddings`.
 
 Recipe: https://github.com/vcruz305/Qwen3.8-Flash-Next-EXL3-DGX-Spark-recipe
 
+### Long-prompt quality check
+
+Short prompts route few rows per expert and never reach the fat-expert prefill path, so a pack can generate fluent text while its long-prompt output is wrong. Before this fix, packs whose gate and up experts carry distinct `suh` rotations (turboderp's native Qwen3.8-Flash-Next pack, for example) scored mean NLL 4.21 over a 6000-token prompt through vLLM against 0.94 through exllamav3 on the same weights; every release up to 0.3.x is affected. After changing anything on the expert path, score a few-thousand-token text with `prompt_logprobs` through vLLM and through exllamav3 on the same token ids and compare per-token NLL; a mean difference above about 0.05 nats is a bug. Setting `VLLM_EXL3_FAT_THRESHOLD=1000000000` disables the fat path as a workaround on older builds.
+
 ## Config contract
 
 The pack's `config.json` must declare the quantization; without it, vLLM

--- a/src/vllm_exl3/exl3.py
+++ b/src/vllm_exl3/exl3.py
@@ -989,6 +989,15 @@ def _fat_scratch(
         "w_up": torch.empty(
             (hidden, intermediate), dtype=torch.float16, device=device
         ),
+        # Contiguous per-projection outputs for the distinct-suh branch: the
+        # extension GEMM and Hadamard kernels index row-major contiguous
+        # operands, so column slices of ``gate_up`` must not be handed to them.
+        "g_tmp": torch.empty(
+            (bucketed_cap, intermediate), dtype=torch.float32, device=device
+        ),
+        "u_tmp": torch.empty(
+            (bucketed_cap, intermediate), dtype=torch.float32, device=device
+        ),
     }
     _FAT_SCRATCH_CACHE[key] = scratch
     return scratch
@@ -1069,30 +1078,27 @@ def apply_exl3_batched_fat(
                 w_up = scratch["w_up"]
                 ext.reconstruct(w_gate, gate.trellis, k, mcg, mul1)
                 ext.reconstruct(w_up, up.trellis, k, mcg, mul1)
-                ext.hgemm(gate_h, w_gate, gate_up[:, :intermediate])
-                ext.hgemm(up_h, w_up, gate_up[:, intermediate:])
-                ext.had_r_128(
-                    gate_up[:, :intermediate],
-                    gate_up[:, :intermediate],
-                    None,
-                    gate.svh,
-                    1.0,
-                )
-                ext.had_r_128(
-                    gate_up[:, intermediate:],
-                    gate_up[:, intermediate:],
-                    None,
-                    up.svh,
-                    1.0,
-                )
+                # Contiguous temporaries: ext.hgemm / ext.had_r_128 read and
+                # write row-major contiguous matrices, and a column slice of
+                # ``gate_up`` is neither (see patch_fat_distinct).
+                g_tmp = scratch["g_tmp"][:n_rows]
+                u_tmp = scratch["u_tmp"][:n_rows]
+                ext.hgemm(gate_h, w_gate, g_tmp)
+                ext.hgemm(up_h, w_up, u_tmp)
+                ext.had_r_128(g_tmp, g_tmp, None, gate.svh, 1.0)
+                ext.had_r_128(u_tmp, u_tmp, None, up.svh, 1.0)
             else:
                 w13 = scratch["w13"]
                 ext.reconstruct(w13, packed13, k, mcg, mul1)
                 ext.hgemm(h13, w13, gate_up)
                 ext.had_r_128(gate_up, gate_up, None, svh13, 1.0)
 
-        gate_out = gate_up[:, :intermediate]
-        up_out = gate_up[:, intermediate:]
+        if distinct_suh:
+            gate_out = scratch["g_tmp"][:n_rows]
+            up_out = scratch["u_tmp"][:n_rows]
+        else:
+            gate_out = gate_up[:, :intermediate]
+            up_out = gate_up[:, intermediate:]
         if limit is not None and limit > 0:
             gate_out.clamp_(max=limit)
             up_out.clamp_(min=-limit, max=limit)

--- a/tests/test_fat_distinct_suh.py
+++ b/tests/test_fat_distinct_suh.py
@@ -1,0 +1,161 @@
+"""CPU regression test for the fat-expert prefill path with distinct gate/up input rotations.
+
+Packs that quantize gate_proj and up_proj separately carry different ``suh`` vectors, so
+``apply_exl3_batched_fat`` takes its distinct-suh branch. That branch used to hand column slices
+of the shared ``gate_up`` scratch buffer to ``ext.hgemm`` and ``ext.had_r_128``; both extension
+kernels index contiguous row-major operands, so the expert output was uncorrelated with the
+reference. The fake extension below refuses non-contiguous operands, which is exactly what the
+real kernels silently mis-read, and the pure-torch reference uses the same fake arithmetic.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import vllm_exl3.exl3 as exl3
+
+HIDDEN = 256
+INTER = 128
+K = 3
+N_ROWS = 300  # above FAT cap of 256, so the fat path runs
+CAP = 256
+
+
+class _FakeExt:
+    """Deterministic stand-in for exllamav3_ext that rejects strided operands."""
+
+    def __init__(self) -> None:
+        self.hgemm_out_shapes: list[tuple[int, ...]] = []
+
+    @staticmethod
+    def _contiguous(name: str, *tensors) -> None:
+        for t in tensors:
+            if t is not None and not t.is_contiguous():
+                raise AssertionError(f"{name}: non-contiguous operand {tuple(t.shape)} {t.stride()}")
+
+    @staticmethod
+    def weight_for(trellis: torch.Tensor, shape: tuple[int, int]) -> torch.Tensor:
+        gen = torch.Generator().manual_seed(int(trellis.to(torch.int64).sum().item()) & 0xFFFF)
+        return (torch.randn(shape, generator=gen) * 0.05).to(torch.float16)
+
+    def reconstruct(self, w, trellis, k, mcg, mul1) -> None:
+        self._contiguous("reconstruct", w, trellis)
+        w.copy_(self.weight_for(trellis, tuple(w.shape)))
+
+    def hgemm(self, a, b, c) -> None:
+        self._contiguous("hgemm", a, b, c)
+        self.hgemm_out_shapes.append(tuple(c.shape))
+        c.copy_((a.float() @ b.float()).to(c.dtype))
+
+    def had_r_128(self, x, out, suh, svh, scale) -> None:
+        self._contiguous("had_r_128", x, out, suh, svh)
+        y = x.float()
+        if suh is not None:
+            y = y * suh.float()
+        if svh is not None:
+            y = y * svh.float()
+        out.copy_((y * float(scale)).to(out.dtype))
+
+
+def _projection(in_features: int, out_features: int, seed: int) -> SimpleNamespace:
+    gen = torch.Generator().manual_seed(seed)
+    return SimpleNamespace(
+        trellis=torch.randint(-3, 4, (in_features // 16, out_features // 16, 16 * K), generator=gen, dtype=torch.int16),
+        suh=(torch.rand(in_features, generator=gen) + 0.5).to(torch.float16),
+        svh=(torch.rand(out_features, generator=gen) + 0.5).to(torch.float16),
+        K=K,
+        mcg=False,
+        mul1=True,
+        in_features=in_features,
+        out_features=out_features,
+    )
+
+
+def _reference(ext: _FakeExt, xh, gate, up, down, weight: float) -> torch.Tensor:
+    w_gate = ext.weight_for(gate.trellis, (HIDDEN, INTER))
+    w_up = ext.weight_for(up.trellis, (HIDDEN, INTER))
+    w_down = ext.weight_for(down.trellis, (INTER, HIDDEN))
+    gate_h = (xh.float() * gate.suh.float()).to(torch.float16)
+    up_h = (xh.float() * up.suh.float()).to(torch.float16)
+    g = (gate_h.float() @ w_gate.float()) * gate.svh.float()
+    u = (up_h.float() @ w_up.float()) * up.svh.float()
+    act = torch.sigmoid(g) * g * u
+    act_h = act.to(torch.float16)
+    h2 = (act_h.float() * down.suh.float()).to(torch.float16)
+    d = (h2.float() @ w_down.float()) * down.svh.float()
+    return d * weight
+
+
+def test_distinct_suh_fat_branch_matches_reference(monkeypatch) -> None:
+    ext = _FakeExt()
+    monkeypatch.setattr(exl3, "load_exllamav3_ext", lambda: ext)
+    monkeypatch.setattr(exl3, "_load_native_exl3_ext", lambda: None)
+    exl3._FAT_SCRATCH_CACHE.clear()
+
+    gate = _projection(HIDDEN, INTER, seed=1)
+    up = _projection(HIDDEN, INTER, seed=2)
+    down = _projection(INTER, HIDDEN, seed=3)
+    assert not torch.equal(gate.suh, up.suh)
+
+    gen = torch.Generator().manual_seed(7)
+    xh = (torch.randn(N_ROWS, HIDDEN, generator=gen) * 0.5).to(torch.float16)
+    token_sorted = torch.arange(N_ROWS, dtype=torch.int64)
+    weight_sorted = torch.full((N_ROWS,), 0.5, dtype=torch.float32)
+    out = torch.zeros(N_ROWS, HIDDEN, dtype=torch.float32)
+
+    exl3.apply_exl3_batched_fat(
+        xh,
+        token_sorted,
+        weight_sorted,
+        [N_ROWS],
+        [{"gate": gate, "up": up, "down": down}],
+        None,
+        CAP,
+        out,
+        use_kernel=False,
+    )
+
+    ref = _reference(ext, xh, gate, up, down, 0.5)
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
+    # gate and up GEMMs must land in contiguous [rows, intermediate] temporaries
+    assert (N_ROWS, INTER) in ext.hgemm_out_shapes
+    exl3._FAT_SCRATCH_CACHE.clear()
+
+
+def test_shared_suh_fat_branch_still_matches_reference(monkeypatch) -> None:
+    ext = _FakeExt()
+    monkeypatch.setattr(exl3, "load_exllamav3_ext", lambda: ext)
+    monkeypatch.setattr(exl3, "_load_native_exl3_ext", lambda: None)
+    exl3._FAT_SCRATCH_CACHE.clear()
+
+    gate = _projection(HIDDEN, INTER, seed=11)
+    up = _projection(HIDDEN, INTER, seed=12)
+    up.suh = gate.suh.clone()
+    down = _projection(INTER, HIDDEN, seed=13)
+
+    gen = torch.Generator().manual_seed(8)
+    xh = (torch.randn(N_ROWS, HIDDEN, generator=gen) * 0.5).to(torch.float16)
+    token_sorted = torch.arange(N_ROWS, dtype=torch.int64)
+    weight_sorted = torch.full((N_ROWS,), 0.5, dtype=torch.float32)
+    out = torch.zeros(N_ROWS, HIDDEN, dtype=torch.float32)
+
+    exl3.apply_exl3_batched_fat(
+        xh, token_sorted, weight_sorted, [N_ROWS], [{"gate": gate, "up": up, "down": down}], None, CAP, out, use_kernel=False
+    )
+
+    # the shared branch reconstructs one fused [hidden, 2*inter] weight from the concatenated trellis,
+    # so build the reference from that same fused weight
+    packed13 = torch.cat([gate.trellis, up.trellis], dim=1).contiguous()
+    w13 = ext.weight_for(packed13, (HIDDEN, 2 * INTER))
+    w_down = ext.weight_for(down.trellis, (INTER, HIDDEN))
+    h13 = (xh.float() * gate.suh.float()).to(torch.float16)
+    svh13 = torch.cat([gate.svh, up.svh]).float()
+    gu = (h13.float() @ w13.float()) * svh13
+    g, u = gu[:, :INTER], gu[:, INTER:]
+    act = torch.sigmoid(g) * g * u
+    h2 = (act.to(torch.float16).float() * down.suh.float()).to(torch.float16)
+    ref = (h2.float() @ w_down.float()) * down.svh.float() * 0.5
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
+    exl3._FAT_SCRATCH_CACHE.clear()


### PR DESCRIPTION
## Cause

`apply_exl3_batched_fat` (experts with more than `VLLM_EXL3_FAT_THRESHOLD` routed rows in a prefill chunk) has a branch for packs whose gate and up projections carry distinct `suh` rotations. That branch handed column slices of the shared `[rows, 2*intermediate]` `gate_up` scratch buffer to `ext.hgemm` and `ext.had_r_128`. Both extension kernels index contiguous row-major operands, so the expert output was uncorrelated with the reference.

## Effect

- On a Qwen3.8-Flash-Next expert (turboderp's native pack, K=3, mul1, 512 rows): relative error 1.30, cosine similarity 0.01 against the LinearEXL3 forward reference.
- Prompt log-likelihood over a 6000-token corpus on the same pack: mean NLL 4.21 through vLLM versus 0.94 through exllamav3; with the fat path disabled (`VLLM_EXL3_FAT_THRESHOLD=1000000000`) vLLM gives 0.943.
- Short prompts never route more than 256 rows to one expert, so generation and speculative acceptance looked normal. Every long prefill on an affected pack was wrong. Packs with a shared gate/up `suh` (fused gate_up quantization, as in the DSV4 and GLM packs) take the other branch and are not affected.

## Fix

The distinct-suh branch now runs both GEMMs into contiguous fp32 scratch buffers (`g_tmp`, `u_tmp`), applies the output Hadamards in place on them, and uses them as `gate_out`/`up_out`. The shared-suh branch is unchanged. Measured on the box after the fix: relative error 0.0000 (layer 1 expert 0, 512 rows) and 0.0018 (layer 20 expert 7, 1024 rows).

## Test

`tests/test_fat_distinct_suh.py` drives the function with a fake extension that rejects strided operands and checks both branches against a pure-torch reference. It fails on `main` (`hgemm: non-contiguous operand (300, 128) (256, 1)`) and passes with this change. The full suite on the box: 288 passed; the native latency/throughput tests (`test_native_p2b_batched`, `test_native_p2b_moe`, `test_native_gemm`) missed their timing targets because a benchmark occupied the GPU at the time, their parity assertions passed.

## Workaround for older builds

`VLLM_EXL3_FAT_THRESHOLD=1000000000` disables the fat path (slower long prefill, correct output).
