### PR TITLE
feat: DeepSeek V4.1 TP4+EP4 EXL3 compatibility

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -189,8 +189,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("expert_indices"), py::arg("routing_weights"), py::arg("K_gate"),
           py::arg("K_up"), py::arg("K_down"), py::arg("mcg"),
           py::arg("intermediate_size") = 2048, py::arg("swiglu_limit") = 0.0f);
-    // Python must not pass TP2 pointers or a clipping request to an older binary.
-    m.attr("P2B_MOE_ABI_VERSION") = 2;
+    // ABI 3 adds dynamic 128-aligned hidden/intermediate geometry to the
+    // cooperative p2b MoE path. Python must gate new geometries on this value
+    // so an older ABI-2 binary can never be used for DeepSeek V4.1.
+    m.attr("P2B_MOE_ABI_VERSION") = 3;
     m.def("exl3_fat_gemm", &exl3_fat_gemm, "Native EXL3 fat GEMM for large prefill rows",
           py::arg("a"), py::arg("packed"), py::arg("out"), py::arg("svh"),
           py::arg("K"), py::arg("mcg"), py::arg("mul1"));

--- a/csrc/p2b_moe.cu
+++ b/csrc/p2b_moe.cu
@@ -4,6 +4,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <cooperative_groups.h>
 #include <cmath>
+#include <limits>
 
 #include "util.h"
 #include "util.cuh"
@@ -423,11 +424,16 @@ at::Tensor p2b_fused_moe_cuda(const at::Tensor& x, at::Tensor& out,
     int64_t kd, bool mcg, int64_t intermediate_size, float swiglu_limit) {
     TORCH_CHECK(x.is_cuda() && x.scalar_type() == at::kHalf, "fused MoE requires CUDA fp16 input");
     TORCH_CHECK(out.is_cuda() && out.scalar_type() == at::kHalf, "fused MoE output must be CUDA fp16");
-    TORCH_CHECK(x.dim() == 2 && x.size(0) == 1 && x.size(1) == 4096,
-                "fused MoE requires one input row with hidden width 4096");
+    TORCH_CHECK(x.dim() == 2 && x.size(0) == 1,
+                "fused MoE requires exactly one input row");
     TORCH_CHECK(out.sizes() == x.sizes(), "fused MoE output shape must match input");
-    TORCH_CHECK(intermediate_size == 1024 || intermediate_size == 2048,
-                "fused MoE local intermediate width must be 1024 or 2048");
+    TORCH_CHECK(x.size(1) > 0 && x.size(1) % 128 == 0,
+                "fused MoE hidden width must be a positive multiple of 128");
+    TORCH_CHECK(intermediate_size > 0 && intermediate_size % 128 == 0,
+                "fused MoE local intermediate width must be a positive multiple of 128");
+    TORCH_CHECK(x.size(1) <= std::numeric_limits<int>::max() &&
+                intermediate_size <= std::numeric_limits<int>::max(),
+                "fused MoE dimensions exceed int32 kernel indexing");
     TORCH_CHECK(std::isfinite(swiglu_limit) && swiglu_limit >= 0.0f,
                 "fused MoE SwiGLU limit must be finite and nonnegative (0 disables clipping)");
     TORCH_CHECK(mcg && kg == ku && ku == kd && (kg == 2 || kg == 3 || kg == 4), "unsupported fused MoE K");
@@ -449,7 +455,8 @@ at::Tensor p2b_fused_moe_cuda(const at::Tensor& x, at::Tensor& out,
     }
     const c10::cuda::CUDAGuard device_guard(x.device());
     const int e = static_cast<int>(ids.numel());
-    constexpr int m = 1, hidden = 4096;
+    constexpr int m = 1;
+    const int hidden = static_cast<int>(x.size(1));
     const int inter = static_cast<int>(intermediate_size);
 
     auto gate = at::empty({e, m, inter}, x.options());

--- a/docs/DEEPSEEK_V41_TP4_EP4.md
+++ b/docs/DEEPSEEK_V41_TP4_EP4.md
@@ -10,12 +10,18 @@ Use the model at tensor parallel size 4 **with expert parallelism enabled**.
 
 Under vLLM EP, the routed MoE changes from tensor-sharded experts to whole-expert ownership across the original TP group:
 
-| Layout | Experts/rank | Hidden | Intermediate/rank | First-boot EXL3 path |
+| Layout | Experts/rank | Hidden | Intermediate/rank | EXL3 path |
 |---|---:|---:|---:|---|
-| TP4 only | 384 | 5120 | 576 | Not recommended; exceeds the current fused expert-count envelope and creates a 64-element tail in 128-wide native tiles |
+| TP4 only | 384 | 5120 | 576 | Not recommended; exceeds the current ExLlamaV3 fused expert-count envelope and leaves a 64-element tail in 128-wide native tiles |
 | **TP4 + EP4** | **96** | **5120** | **2304** | **Recommended; full experts, dimensions aligned to 128, within ExLlamaV3's 128-local-expert fused envelope** |
 
-The current native `vllm-exl3` p2b kernel remains qualified for the 4096 x {1024, 2048} family. The first V4.1 boot should therefore use the ExLlamaV3 fused expert executor. A dedicated SM121 5120 x 2304 native specialization is a follow-up optimization, not a correctness prerequisite.
+The safe first V4.1 boot remains the ExLlamaV3 fused expert executor. This branch also generalizes the native cooperative p2b kernel to positive 128-aligned hidden/intermediate dimensions and bumps its ABI to **3**. V4.1 native dispatch is intentionally opt-in until GB10 parity and throughput are measured:
+
+```bash
+export VLLM_EXL3_V41_NATIVE_MOE=1
+```
+
+The Python compatibility layer refuses the V4.1 native geometry unless the loaded extension reports `P2B_MOE_ABI_VERSION >= 3`, preventing an older ABI-2 `.so` from being used accidentally.
 
 ## Required EXL3 pack metadata
 
@@ -97,20 +103,27 @@ Run these gates in order. Never change EXL3, Engram, speculative decoding and CU
    - No persistent BF16 reconstruction of routed experts.
    - Start eager for the first correctness pass.
 
-3. **DSpark-5**
+3. **Native p2b A/B**
+   - Rebuild `vllm_exl3_c` from this branch and verify ABI 3.
+   - Hold the checkpoint, prompts, TP4+EP4 topology and sampling constant.
+   - Baseline with `VLLM_EXL3_V41_NATIVE_MOE` unset.
+   - Candidate with `VLLM_EXL3_V41_NATIVE_MOE=1`.
+   - Require output/parity checks before interpreting throughput.
+
+4. **DSpark-5**
    - Keep DSpark experts source-native.
    - Use five speculative tokens, matching the trained V4.1 block size.
    - Begin with adaptive verification disabled on SM121 until the pinned sparse-MLA stack proves padded/variable graph shapes safe.
 
-4. **CUDA graphs**
+5. **CUDA graphs**
    - Capture only after all runtime JIT kernels are prebuilt/warmed.
    - Record exact capture sizes and verify no decode batch is silently padded into an unsupported sparse-MLA shape.
 
-5. **Context scaling**
+6. **Context scaling**
    - Validate 64K, 128K, 300K, then longer contexts.
    - Record KV token capacity, graph pool, peak unified memory, host headroom and per-rank model residency.
 
-6. **Vision/tools**
+7. **Vision/tools**
    - Text correctness first, then enable the vision encoder and V4.1 tool/reasoning parsers.
    - Run at least one image request and one complete tool-call round trip.
 
@@ -147,6 +160,7 @@ For every meaningful A/B, capture:
 - vLLM image digest and source commit;
 - `vllm-exl3` commit;
 - ExLlamaV3 revision;
+- native p2b ABI;
 - CUDA/Torch/FlashInfer/DeepGEMM versions;
 - TP/EP topology and rank-to-expert ownership;
 - EXL3 K per layer;

--- a/docs/DEEPSEEK_V41_TP4_EP4.md
+++ b/docs/DEEPSEEK_V41_TP4_EP4.md
@@ -1,0 +1,162 @@
+# DeepSeek V4.1 Flash: TP4 + EP4 EXL3 bring-up
+
+This document defines the first-boot contract for serving `deepseek-ai/DeepSeek-V4.1-Flash` with `vllm-exl3` on four DGX Sparks.
+
+The plugin does **not** reimplement DeepSeek V4.1. The dedicated vLLM V4.1 runtime owns the architecture, sparse attention, Lightning Indexer, Engram, Hyper-Connections, vision, DSpark, tokenizer, reasoning parser and tool parser. `vllm-exl3` owns the EXL3 expert storage/execution boundary and the mixed-checkpoint delegation contract.
+
+## Recommended parallel layout
+
+Use the model at tensor parallel size 4 **with expert parallelism enabled**.
+
+Under vLLM EP, the routed MoE changes from tensor-sharded experts to whole-expert ownership across the original TP group:
+
+| Layout | Experts/rank | Hidden | Intermediate/rank | First-boot EXL3 path |
+|---|---:|---:|---:|---|
+| TP4 only | 384 | 5120 | 576 | Not recommended; exceeds the current fused expert-count envelope and creates a 64-element tail in 128-wide native tiles |
+| **TP4 + EP4** | **96** | **5120** | **2304** | **Recommended; full experts, dimensions aligned to 128, within ExLlamaV3's 128-local-expert fused envelope** |
+
+The current native `vllm-exl3` p2b kernel remains qualified for the 4096 x {1024, 2048} family. The first V4.1 boot should therefore use the ExLlamaV3 fused expert executor. A dedicated SM121 5120 x 2304 native specialization is a follow-up optimization, not a correctness prerequisite.
+
+## Required EXL3 pack metadata
+
+For a V4.1 pack that EXL3-quantizes the **main routed expert stack** while preserving official source formats for the rest of the checkpoint, the outer config must retain enough source quantization metadata for vLLM's V4.1 architecture-level probes:
+
+```json
+{
+  "quantization_config": {
+    "quant_method": "exl3",
+    "bits": 2,
+    "codebook": "mcg",
+    "scope": "deepseek_v41_routed_experts",
+    "non_routed_quantization": {
+      "quant_method": "deepseek_v4_fp8",
+      "weight_block_size": [32, 32],
+      "activation_scheme": "dynamic"
+    },
+    "mtp_experts": "source"
+  }
+}
+```
+
+Mixed-K packs should keep their existing `layer_bits` ledger. Do not flatten a mixed K2/K3 pack to the base `bits` value.
+
+`vllm-exl3` now surfaces `non_routed_quantization.weight_block_size` through the outer `Exl3Config`. This is required because the V4.1 model inspects the global quantization config before individual dense layers request their delegated quantization method.
+
+### DSpark
+
+For the first boot, keep all three DSpark draft stages in their official source format:
+
+```json
+"mtp_experts": "source"
+```
+
+Existing packs may continue to set:
+
+```json
+"mtp_experts_start_layer": 40
+```
+
+For V4.1 packs that omit the numeric boundary, the plugin can infer DSpark source delegation only when all of the following are true:
+
+- `mtp_experts == "source"`
+- the source delegate is `deepseek_v4_fp8`
+- its block shape is `[32, 32]`
+- the routed block has 128 global experts
+
+The 384-expert main stack remains EXL3.
+
+## Runtime baseline
+
+Start from the dedicated vLLM DeepSeek V4.1 image/runtime rather than stock pip vLLM. Pin the exact image digest and plugin commit used for every measurement.
+
+Minimum logical launch shape:
+
+```bash
+vllm serve /models/DeepSeek-V4.1-Flash-EXL3 \
+  --quantization exl3 \
+  --tokenizer-mode deepseek_v41 \
+  --tensor-parallel-size 4 \
+  --enable-expert-parallel
+```
+
+Do not treat that minimal command as the final DGX Spark launch recipe. SM121 sparse-attention, CUDA-graph and Engram placement must be qualified against the exact pinned V4.1 image.
+
+## First-boot progression
+
+Run these gates in order. Never change EXL3, Engram, speculative decoding and CUDA-graph behavior in the same A/B.
+
+1. **Preflight / no checkpoint**
+   - `plan_deepseek_v41()` reports 96 local experts and `preferred_first_boot_backend=exllamav3`.
+   - `runtime_diagnostics()` reports `deepseek_v41.compat_installed=true`.
+   - Source quantization metadata resolves `weight_block_size=[32,32]`.
+
+2. **TP4 + EP4, source DSpark disabled**
+   - Main routed experts load as EXL3.
+   - Each rank owns 96 expert packs.
+   - Dense/attention/shared weights use the V4.1 source MXFP8 delegate.
+   - No persistent BF16 reconstruction of routed experts.
+   - Start eager for the first correctness pass.
+
+3. **DSpark-5**
+   - Keep DSpark experts source-native.
+   - Use five speculative tokens, matching the trained V4.1 block size.
+   - Begin with adaptive verification disabled on SM121 until the pinned sparse-MLA stack proves padded/variable graph shapes safe.
+
+4. **CUDA graphs**
+   - Capture only after all runtime JIT kernels are prebuilt/warmed.
+   - Record exact capture sizes and verify no decode batch is silently padded into an unsupported sparse-MLA shape.
+
+5. **Context scaling**
+   - Validate 64K, 128K, 300K, then longer contexts.
+   - Record KV token capacity, graph pool, peak unified memory, host headroom and per-rank model residency.
+
+6. **Vision/tools**
+   - Text correctness first, then enable the vision encoder and V4.1 tool/reasoning parsers.
+   - Run at least one image request and one complete tool-call round trip.
+
+## Engram strategy
+
+Engram is a separate storage problem from EXL3 expert execution. For the first distributed boot, use the already-proven Spark-compatible disk/node-local Engram path if the pinned vLLM image still cannot hold Engram safely in unified memory.
+
+After EXL3 expert residency is measured, retry with resident Engram. The goal is to use the memory saved by EXL3 to remove or reduce disk-backed Engram without sacrificing KV/cache headroom.
+
+Do not claim resident Engram until all four ranks report safe peak unified-memory headroom during long-context prefill and DSpark decode.
+
+## DeepSelect
+
+DeepSelect is relevant to V4.1's Lightning Indexer TopK, but it is **not** a first-boot dependency. Its current published build targets SM100/SM103, not SM121. The DGX Spark baseline should first use the best working vLLM SM12x TopK path.
+
+A later SM121 DeepSelect experiment must compare against that optimized baseline rather than against `torch.topk`.
+
+## DeepJIT
+
+DeepJIT is a promising future backend for shape-specialized EXL3 kernels, but it is not required to boot V4.1. DeepGEMM already embeds DeepJIT in the V4.1 runtime stack.
+
+If `vllm-exl3` adopts DeepJIT later:
+
+- compile before CUDA graph capture;
+- cache CUBINs by EXL3 format + K + hidden + intermediate + SM architecture + plugin ABI;
+- allow a shared read-only cache across Spark nodes;
+- never trigger an unbounded parallel NVCC build during model startup;
+- keep the AOT/native backend available as a fallback.
+
+## Qualification evidence to retain
+
+For every meaningful A/B, capture:
+
+- vLLM image digest and source commit;
+- `vllm-exl3` commit;
+- ExLlamaV3 revision;
+- CUDA/Torch/FlashInfer/DeepGEMM versions;
+- TP/EP topology and rank-to-expert ownership;
+- EXL3 K per layer;
+- actual expert backend dispatch, not just requested backend;
+- DSpark proposed/accepted tokens and acceptance length;
+- TTFT, TPOT, output tok/s and aggregate tok/s;
+- peak allocated/reserved/unified memory per rank;
+- KV token capacity;
+- Engram placement;
+- CUDA graph mode/capture sizes;
+- GB10 clocks/power during the run.
+
+A skipped GPU test is not a hardware qualification pass.

--- a/src/vllm_exl3/__init__.py
+++ b/src/vllm_exl3/__init__.py
@@ -14,20 +14,30 @@ __all__ = [
     "grouped_prefill_max_rows",
     "grouped_prefill_scratch_bytes",
     "plan_grouped_prefill",
+    "DeepseekV41Plan",
+    "plan_deepseek_v41",
+    "source_weight_block_size",
+    "is_deepseek_v41_source_quant",
+    "should_delegate_dspark_source",
 ]
 
 
 def register() -> None:
     # Importing the module executes its register_quantization_config decorator.
     from . import exl3
+    from .deepseek_v41 import install_deepseek_v41_compat
     from .runtime_policy import install_native_row_policy
 
+    # Install model-family compatibility before runtime policy wrappers inspect
+    # the quantization config. vLLM still owns the DeepSeek V4.1 architecture.
+    install_deepseek_v41_compat(exl3)
     install_native_row_policy(exl3)
 
 
 def runtime_diagnostics():
     """Return effective EXL3 runtime policy and extension availability."""
     from . import exl3
+    from .deepseek_v41 import plan_deepseek_v41
     from .prefill_policy import grouped_prefill_enabled, grouped_prefill_max_rows
     from .runtime_policy import diagnostics, fused_temp_rows_requested, native_row_cap
 
@@ -59,6 +69,12 @@ def runtime_diagnostics():
         "max_rows_per_window": grouped_prefill_max_rows(),
         "execution_available": False,
     }
+    record["deepseek_v41"] = {
+        "compat_installed": bool(
+            getattr(exl3, "_vllm_exl3_v41_compat_installed", False)
+        ),
+        "recommended_tp4_ep4": plan_deepseek_v41().to_dict(),
+    }
     return record
 
 
@@ -83,4 +99,13 @@ def __getattr__(name: str):
     }:
         from . import prefill_policy
         return getattr(prefill_policy, name)
+    if name in {
+        "DeepseekV41Plan",
+        "plan_deepseek_v41",
+        "source_weight_block_size",
+        "is_deepseek_v41_source_quant",
+        "should_delegate_dspark_source",
+    }:
+        from . import deepseek_v41
+        return getattr(deepseek_v41, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/vllm_exl3/deepseek_v41.py
+++ b/src/vllm_exl3/deepseek_v41.py
@@ -1,0 +1,264 @@
+"""DeepSeek V4.1 compatibility helpers for the EXL3 serving plugin.
+
+This module intentionally does not reimplement the DeepSeek V4.1 model. vLLM owns
+that architecture. The helpers here bridge EXL3's mixed-checkpoint metadata into
+vLLM's model-level quantization probes and describe the TP4+EP4 layout that is a
+better fit for EXL3 on four DGX Sparks.
+
+The policy is independently implemented from public vLLM/DeepSeek interfaces.
+No DeepSeek or vLLM source code is copied into this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Any, Mapping
+
+DEEPSEEK_V41_MAIN_EXPERTS = 384
+DEEPSEEK_V41_DSPARK_EXPERTS = 128
+DEEPSEEK_V41_TOPK = 6
+DEEPSEEK_V41_HIDDEN = 5120
+DEEPSEEK_V41_INTERMEDIATE = 2304
+DEEPSEEK_V41_DSPARK_STAGES = 3
+DEEPSEEK_V41_DSPARK_TOKENS = 5
+EXLLAMAV3_FUSED_EXPERT_LIMIT = 128
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _normalize_block_size(value: object) -> tuple[int, int] | None:
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        return None
+    try:
+        rows, cols = int(value[0]), int(value[1])
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if rows <= 0 or cols <= 0:
+        return None
+    return rows, cols
+
+
+def source_quantization_config(config: object) -> Mapping[str, Any]:
+    """Return the declared non-routed/source quantization metadata."""
+    return _mapping(getattr(config, "non_routed_quantization", None))
+
+
+def source_weight_block_size(config: object) -> list[int] | None:
+    """Expose the source dense-weight block shape to architecture-level probes.
+
+    DeepSeek V4.1's vLLM model inspects the *global* quantization config before
+    individual dense layers ask EXL3 for their delegated quant method. EXL3 packs
+    that preserve the source MXFP8 dense weights therefore need to surface the
+    delegate's [32, 32] block shape at the outer config as well.
+    """
+    block = _normalize_block_size(source_quantization_config(config).get("weight_block_size"))
+    return list(block) if block is not None else None
+
+
+def is_deepseek_v41_source_quant(config: object) -> bool:
+    """Whether config declares the native V4/V4.1 MXFP8 dense-weight delegate."""
+    source = source_quantization_config(config)
+    method = str(source.get("quant_method", "")).strip().lower()
+    return method == "deepseek_v4_fp8" and _normalize_block_size(
+        source.get("weight_block_size")
+    ) == (32, 32)
+
+
+def _layer_index(prefix: str) -> int | None:
+    match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", str(prefix))
+    return int(match.group(1)) if match else None
+
+
+def should_delegate_dspark_source(
+    config: object,
+    *,
+    prefix: str,
+    global_num_experts: int | None,
+) -> bool:
+    """Return True when a V4.1 DSpark routed block should retain source MXFP4.
+
+    Existing packs can continue to declare ``mtp_experts_start_layer``. For V4.1
+    packs that omit it, the 128-expert DSpark blocks are distinguishable from the
+    384-expert main stack, so the plugin can safely infer the source delegation
+    when the V4.1 dense-source quantization signature is also present.
+    """
+    if str(getattr(config, "mtp_experts", "exl3")).strip().lower() != "source":
+        return False
+
+    layer_index = _layer_index(prefix)
+    explicit_start = getattr(config, "mtp_experts_start_layer", None)
+    if explicit_start is not None:
+        try:
+            return layer_index is not None and layer_index >= int(explicit_start)
+        except (TypeError, ValueError, OverflowError):
+            return False
+
+    return (
+        is_deepseek_v41_source_quant(config)
+        and global_num_experts == DEEPSEEK_V41_DSPARK_EXPERTS
+    )
+
+
+@dataclass(frozen=True)
+class DeepseekV41Plan:
+    tensor_parallel_size: int
+    expert_parallel: bool
+    moe_tensor_parallel_size: int
+    expert_parallel_size: int
+    global_experts: int
+    local_experts: int
+    hidden_size: int
+    intermediate_size: int
+    intermediate_size_per_rank: int
+    top_k: int
+    exllamav3_fused_candidate: bool
+    native_p2b_candidate: bool
+    preferred_first_boot_backend: str
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def plan_deepseek_v41(
+    *,
+    tensor_parallel_size: int = 4,
+    expert_parallel: bool = True,
+    global_experts: int = DEEPSEEK_V41_MAIN_EXPERTS,
+    hidden_size: int = DEEPSEEK_V41_HIDDEN,
+    intermediate_size: int = DEEPSEEK_V41_INTERMEDIATE,
+    top_k: int = DEEPSEEK_V41_TOPK,
+) -> DeepseekV41Plan:
+    """Describe the routed-expert layout for a DeepSeek V4.1 deployment.
+
+    Under vLLM expert parallelism, the MoE stops tensor-sharding each expert and
+    instead shards whole experts over the original TP group. This is the desired
+    four-Spark EXL3 layout: 96 complete 5120x2304 experts per rank rather than
+    384 experts with an awkward 576-wide TP partition.
+    """
+    values = {
+        "tensor_parallel_size": tensor_parallel_size,
+        "global_experts": global_experts,
+        "hidden_size": hidden_size,
+        "intermediate_size": intermediate_size,
+        "top_k": top_k,
+    }
+    for name, value in values.items():
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+
+    if global_experts % tensor_parallel_size:
+        raise ValueError("global_experts must divide evenly across TP/EP ranks")
+    if not expert_parallel and intermediate_size % tensor_parallel_size:
+        raise ValueError("intermediate_size must divide evenly for pure TP")
+
+    if expert_parallel:
+        moe_tp = 1
+        ep_size = tensor_parallel_size
+        local_experts = global_experts // ep_size
+        inter_local = intermediate_size
+    else:
+        moe_tp = tensor_parallel_size
+        ep_size = 1
+        local_experts = global_experts
+        inter_local = intermediate_size // tensor_parallel_size
+
+    exllamav3_candidate = (
+        local_experts <= EXLLAMAV3_FUSED_EXPERT_LIMIT
+        and hidden_size % 128 == 0
+        and inter_local % 128 == 0
+    )
+    # Current vllm-exl3 native p2b ABI is still the qualified 4096 x {1024,2048}
+    # family. Keep this false for V4.1 until the dedicated SM121 specialization
+    # is implemented and GPU-qualified.
+    native_candidate = hidden_size == 4096 and inter_local in (1024, 2048)
+
+    if expert_parallel and exllamav3_candidate:
+        backend = "exllamav3"
+        reason = (
+            "TP4+EP4 keeps full experts on each rank: 96 local experts at "
+            "5120x2304, within the ExLlamaV3 fused expert-count/alignment envelope"
+        )
+    elif exllamav3_candidate:
+        backend = "exllamav3"
+        reason = "layout is fused-compatible, but pure TP is not the preferred Spark path"
+    else:
+        backend = "loop"
+        reason = "layout exceeds the currently qualified fused EXL3 envelope"
+
+    return DeepseekV41Plan(
+        tensor_parallel_size=tensor_parallel_size,
+        expert_parallel=expert_parallel,
+        moe_tensor_parallel_size=moe_tp,
+        expert_parallel_size=ep_size,
+        global_experts=global_experts,
+        local_experts=local_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        intermediate_size_per_rank=inter_local,
+        top_k=top_k,
+        exllamav3_fused_candidate=exllamav3_candidate,
+        native_p2b_candidate=native_candidate,
+        preferred_first_boot_backend=backend,
+        reason=reason,
+    )
+
+
+def install_deepseek_v41_compat(exl3_module: object) -> None:
+    """Install narrow V4.1 compatibility shims onto ``Exl3Config`` once.
+
+    The shim has two jobs only:
+    1. Surface the delegated source block shape through the outer EXL3 config so
+       vLLM V4.1 can choose the correct MXFP8 scale naming/layout.
+    2. Allow V4.1's 128-expert DSpark blocks to remain source MXFP4 when a pack
+       requests ``mtp_experts=source`` but omits a numeric start-layer marker.
+
+    All actual model architecture, attention, Engram, routing and DSpark execution
+    remain owned by vLLM.
+    """
+    if bool(getattr(exl3_module, "_vllm_exl3_v41_compat_installed", False)):
+        return
+
+    config_cls = getattr(exl3_module, "Exl3Config")
+
+    if "weight_block_size" not in config_cls.__dict__:
+        setattr(config_cls, "weight_block_size", property(source_weight_block_size))
+
+    if "has_blocked_weights" not in config_cls.__dict__:
+        def has_blocked_weights(self) -> bool:
+            return source_weight_block_size(self) is not None
+        setattr(config_cls, "has_blocked_weights", has_blocked_weights)
+
+    original_get_quant_method = config_cls.get_quant_method
+    if not bool(getattr(original_get_quant_method, "_vllm_exl3_v41_wrapped", False)):
+        def get_quant_method_v41(self, layer, prefix):
+            try:
+                from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+            except Exception:
+                RoutedExperts = ()  # type: ignore[assignment]
+
+            if RoutedExperts and isinstance(layer, RoutedExperts):
+                global_num_experts = getattr(layer, "global_num_experts", None)
+                if global_num_experts is None:
+                    global_num_experts = getattr(
+                        getattr(layer, "moe_config", None), "num_experts", None
+                    )
+                if should_delegate_dspark_source(
+                    self,
+                    prefix=prefix,
+                    global_num_experts=global_num_experts,
+                ):
+                    resolver = getattr(self, "_mtp_expert_method", None)
+                    if callable(resolver):
+                        method, _how = resolver(layer, prefix)
+                        if method is not None:
+                            return method
+            return original_get_quant_method(self, layer, prefix)
+
+        get_quant_method_v41._vllm_exl3_v41_wrapped = True  # type: ignore[attr-defined]
+        setattr(config_cls, "get_quant_method", get_quant_method_v41)
+
+    setattr(exl3_module, "_vllm_exl3_v41_compat_installed", True)

--- a/src/vllm_exl3/deepseek_v41.py
+++ b/src/vllm_exl3/deepseek_v41.py
@@ -12,6 +12,8 @@ No DeepSeek or vLLM source code is copied into this module.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import math
+import os
 import re
 from typing import Any, Mapping
 
@@ -23,6 +25,8 @@ DEEPSEEK_V41_INTERMEDIATE = 2304
 DEEPSEEK_V41_DSPARK_STAGES = 3
 DEEPSEEK_V41_DSPARK_TOKENS = 5
 EXLLAMAV3_FUSED_EXPERT_LIMIT = 128
+V41_NATIVE_MOE_ENV = "VLLM_EXL3_V41_NATIVE_MOE"
+V41_NATIVE_MOE_ABI = 3
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -39,6 +43,13 @@ def _normalize_block_size(value: object) -> tuple[int, int] | None:
     if rows <= 0 or cols <= 0:
         return None
     return rows, cols
+
+
+def _env_enabled(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def source_quantization_config(config: object) -> Mapping[str, Any]:
@@ -102,6 +113,21 @@ def should_delegate_dspark_source(
     )
 
 
+def native_p2b_geometry_supported(hidden_size: int, intermediate_size: int) -> bool:
+    """Whether ABI-3 p2b geometry can cover the dimensions without 128 tails."""
+    return (
+        hidden_size > 0
+        and intermediate_size > 0
+        and hidden_size % 128 == 0
+        and intermediate_size % 128 == 0
+    )
+
+
+def v41_native_moe_requested() -> bool:
+    """V4.1 native p2b remains opt-in until GB10 parity/throughput qualification."""
+    return _env_enabled(V41_NATIVE_MOE_ENV, False)
+
+
 @dataclass(frozen=True)
 class DeepseekV41Plan:
     tensor_parallel_size: int
@@ -116,6 +142,8 @@ class DeepseekV41Plan:
     top_k: int
     exllamav3_fused_candidate: bool
     native_p2b_candidate: bool
+    native_p2b_requires_abi: int
+    native_p2b_default_enabled: bool
     preferred_first_boot_backend: str
     reason: str
 
@@ -168,26 +196,23 @@ def plan_deepseek_v41(
 
     exllamav3_candidate = (
         local_experts <= EXLLAMAV3_FUSED_EXPERT_LIMIT
-        and hidden_size % 128 == 0
-        and inter_local % 128 == 0
+        and native_p2b_geometry_supported(hidden_size, inter_local)
     )
-    # Current vllm-exl3 native p2b ABI is still the qualified 4096 x {1024,2048}
-    # family. Keep this false for V4.1 until the dedicated SM121 specialization
-    # is implemented and GPU-qualified.
-    native_candidate = hidden_size == 4096 and inter_local in (1024, 2048)
+    native_candidate = native_p2b_geometry_supported(hidden_size, inter_local)
 
     if expert_parallel and exllamav3_candidate:
         backend = "exllamav3"
         reason = (
             "TP4+EP4 keeps full experts on each rank: 96 local experts at "
-            "5120x2304, within the ExLlamaV3 fused expert-count/alignment envelope"
+            "5120x2304. ExLlamaV3 is the safe first-boot backend; ABI-3 native "
+            "p2b is available as an explicit post-parity A/B."
         )
     elif exllamav3_candidate:
         backend = "exllamav3"
         reason = "layout is fused-compatible, but pure TP is not the preferred Spark path"
     else:
         backend = "loop"
-        reason = "layout exceeds the currently qualified fused EXL3 envelope"
+        reason = "layout exceeds the currently aligned fused EXL3 envelope"
 
     return DeepseekV41Plan(
         tensor_parallel_size=tensor_parallel_size,
@@ -202,19 +227,66 @@ def plan_deepseek_v41(
         top_k=top_k,
         exllamav3_fused_candidate=exllamav3_candidate,
         native_p2b_candidate=native_candidate,
+        native_p2b_requires_abi=V41_NATIVE_MOE_ABI,
+        native_p2b_default_enabled=False,
         preferred_first_boot_backend=backend,
         reason=reason,
     )
 
 
+def _install_native_geometry_wrapper(exl3_module: object) -> None:
+    original = getattr(exl3_module, "_native_moe_dimensions_supported", None)
+    if not callable(original) or bool(
+        getattr(original, "_vllm_exl3_v41_geometry_wrapped", False)
+    ):
+        return
+
+    def dimensions_supported_v41(x2d, layer, inners, limit=None):
+        if original(x2d, layer, inners, limit):
+            return True
+        if not v41_native_moe_requested():
+            return False
+        try:
+            if x2d.dim() != 2 or not x2d.is_cuda:
+                return False
+            if limit is not None and (not math.isfinite(limit) or limit < 0):
+                return False
+            hidden = int(getattr(layer, "_exl3_hidden_size", x2d.shape[1]))
+            intermediate = int(getattr(layer, "_exl3_intermediate_local", 0))
+            bits = int(getattr(layer, "_exl3_k", getattr(layer, "_exl3_bits", -1)))
+            rows = int(x2d.shape[0])
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            return False
+
+        if not (
+            hidden == DEEPSEEK_V41_HIDDEN
+            and intermediate == DEEPSEEK_V41_INTERMEDIATE
+            and int(x2d.shape[1]) == hidden
+            and native_p2b_geometry_supported(hidden, intermediate)
+            and bits in (2, 3, 4)
+            and rows >= 1
+            and len(inners) > 0
+        ):
+            return False
+
+        native = exl3_module._load_native_exl3_ext()
+        if native is None or int(getattr(native, "P2B_MOE_ABI_VERSION", 0)) < V41_NATIVE_MOE_ABI:
+            return False
+        return rows <= exl3_module._native_moe_max_rows(bits)
+
+    dimensions_supported_v41._vllm_exl3_v41_geometry_wrapped = True  # type: ignore[attr-defined]
+    setattr(exl3_module, "_native_moe_dimensions_supported", dimensions_supported_v41)
+
+
 def install_deepseek_v41_compat(exl3_module: object) -> None:
     """Install narrow V4.1 compatibility shims onto ``Exl3Config`` once.
 
-    The shim has two jobs only:
+    The shim has three jobs only:
     1. Surface the delegated source block shape through the outer EXL3 config so
        vLLM V4.1 can choose the correct MXFP8 scale naming/layout.
     2. Allow V4.1's 128-expert DSpark blocks to remain source MXFP4 when a pack
        requests ``mtp_experts=source`` but omits a numeric start-layer marker.
+    3. Add an opt-in ABI-3 native geometry path for the aligned EP4 expert shape.
 
     All actual model architecture, attention, Engram, routing and DSpark execution
     remain owned by vLLM.
@@ -261,4 +333,5 @@ def install_deepseek_v41_compat(exl3_module: object) -> None:
         get_quant_method_v41._vllm_exl3_v41_wrapped = True  # type: ignore[attr-defined]
         setattr(config_cls, "get_quant_method", get_quant_method_v41)
 
+    _install_native_geometry_wrapper(exl3_module)
     setattr(exl3_module, "_vllm_exl3_v41_compat_installed", True)

--- a/tests/test_deepseek_v41.py
+++ b/tests/test_deepseek_v41.py
@@ -27,6 +27,30 @@ def _v41_config(**overrides):
     return SimpleNamespace(**values)
 
 
+def _fake_exl3_module(native_abi=3):
+    class FakeConfig:
+        def __init__(self):
+            self.non_routed_quantization = {
+                "quant_method": "deepseek_v4_fp8",
+                "weight_block_size": [32, 32],
+            }
+
+        def get_quant_method(self, layer, prefix):
+            return None
+
+    def existing_dimensions_supported(x2d, layer, inners, limit=None):
+        return False
+
+    return SimpleNamespace(
+        Exl3Config=FakeConfig,
+        _native_moe_dimensions_supported=existing_dimensions_supported,
+        _load_native_exl3_ext=lambda: SimpleNamespace(
+            P2B_MOE_ABI_VERSION=native_abi
+        ),
+        _native_moe_max_rows=lambda bits: 8,
+    )
+
+
 def test_tp4_ep4_is_the_fused_first_boot_layout():
     plan = plan_deepseek_v41()
     assert plan.tensor_parallel_size == 4
@@ -61,6 +85,26 @@ def test_native_geometry_requires_128_aligned_dimensions():
     assert native_p2b_geometry_supported(4096, 2048) is True
     assert native_p2b_geometry_supported(5120, 576) is False
     assert native_p2b_geometry_supported(0, 2304) is False
+
+
+def test_v41_native_geometry_is_opt_in_and_requires_abi3(monkeypatch):
+    x = SimpleNamespace(shape=(1, 5120), is_cuda=True, dim=lambda: 2)
+    layer = SimpleNamespace(
+        _exl3_hidden_size=5120,
+        _exl3_intermediate_local=2304,
+        _exl3_k=2,
+    )
+
+    module = _fake_exl3_module(native_abi=3)
+    install_deepseek_v41_compat(module)
+    assert not module._native_moe_dimensions_supported(x, layer, [{}], 10.0)
+
+    monkeypatch.setenv("VLLM_EXL3_V41_NATIVE_MOE", "1")
+    assert module._native_moe_dimensions_supported(x, layer, [{}], 10.0)
+
+    stale = _fake_exl3_module(native_abi=2)
+    install_deepseek_v41_compat(stale)
+    assert not stale._native_moe_dimensions_supported(x, layer, [{}], 10.0)
 
 
 def test_source_quantization_traits_surface_v41_mxfp8_block_shape():
@@ -118,28 +162,12 @@ def test_dspark_inference_fails_closed_without_source_request():
 
 
 def test_installer_surfaces_outer_weight_block_size_and_is_idempotent():
-    class FakeConfig:
-        def __init__(self):
-            self.non_routed_quantization = {
-                "quant_method": "deepseek_v4_fp8",
-                "weight_block_size": [32, 32],
-            }
-
-        def get_quant_method(self, layer, prefix):
-            return None
-
-    def existing_dimensions_supported(x2d, layer, inners, limit=None):
-        return False
-
-    module = SimpleNamespace(
-        Exl3Config=FakeConfig,
-        _native_moe_dimensions_supported=existing_dimensions_supported,
-    )
+    module = _fake_exl3_module()
     install_deepseek_v41_compat(module)
     wrapped_dimensions = module._native_moe_dimensions_supported
     install_deepseek_v41_compat(module)
 
-    config = FakeConfig()
+    config = module.Exl3Config()
     assert config.weight_block_size == [32, 32]
     assert config.has_blocked_weights() is True
     assert module._vllm_exl3_v41_compat_installed is True

--- a/tests/test_deepseek_v41.py
+++ b/tests/test_deepseek_v41.py
@@ -3,8 +3,10 @@ from types import SimpleNamespace
 import pytest
 
 from vllm_exl3.deepseek_v41 import (
+    V41_NATIVE_MOE_ABI,
     install_deepseek_v41_compat,
     is_deepseek_v41_source_quant,
+    native_p2b_geometry_supported,
     plan_deepseek_v41,
     should_delegate_dspark_source,
     source_weight_block_size,
@@ -37,7 +39,9 @@ def test_tp4_ep4_is_the_fused_first_boot_layout():
     assert plan.intermediate_size_per_rank == 2304
     assert plan.top_k == 6
     assert plan.exllamav3_fused_candidate is True
-    assert plan.native_p2b_candidate is False
+    assert plan.native_p2b_candidate is True
+    assert plan.native_p2b_requires_abi == V41_NATIVE_MOE_ABI == 3
+    assert plan.native_p2b_default_enabled is False
     assert plan.preferred_first_boot_backend == "exllamav3"
 
 
@@ -50,6 +54,13 @@ def test_pure_tp4_exposes_the_576_wide_problem():
     assert plan.exllamav3_fused_candidate is False
     assert plan.native_p2b_candidate is False
     assert plan.preferred_first_boot_backend == "loop"
+
+
+def test_native_geometry_requires_128_aligned_dimensions():
+    assert native_p2b_geometry_supported(5120, 2304) is True
+    assert native_p2b_geometry_supported(4096, 2048) is True
+    assert native_p2b_geometry_supported(5120, 576) is False
+    assert native_p2b_geometry_supported(0, 2304) is False
 
 
 def test_source_quantization_traits_surface_v41_mxfp8_block_shape():
@@ -117,14 +128,22 @@ def test_installer_surfaces_outer_weight_block_size_and_is_idempotent():
         def get_quant_method(self, layer, prefix):
             return None
 
-    module = SimpleNamespace(Exl3Config=FakeConfig)
+    def existing_dimensions_supported(x2d, layer, inners, limit=None):
+        return False
+
+    module = SimpleNamespace(
+        Exl3Config=FakeConfig,
+        _native_moe_dimensions_supported=existing_dimensions_supported,
+    )
     install_deepseek_v41_compat(module)
+    wrapped_dimensions = module._native_moe_dimensions_supported
     install_deepseek_v41_compat(module)
 
     config = FakeConfig()
     assert config.weight_block_size == [32, 32]
     assert config.has_blocked_weights() is True
     assert module._vllm_exl3_v41_compat_installed is True
+    assert wrapped_dimensions is module._native_moe_dimensions_supported
 
 
 def test_plan_rejects_non_divisible_expert_layout():

--- a/tests/test_deepseek_v41.py
+++ b/tests/test_deepseek_v41.py
@@ -1,0 +1,132 @@
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_exl3.deepseek_v41 import (
+    install_deepseek_v41_compat,
+    is_deepseek_v41_source_quant,
+    plan_deepseek_v41,
+    should_delegate_dspark_source,
+    source_weight_block_size,
+)
+
+
+def _v41_config(**overrides):
+    values = {
+        "non_routed_quantization": {
+            "quant_method": "deepseek_v4_fp8",
+            "weight_block_size": [32, 32],
+            "activation_scheme": "dynamic",
+        },
+        "mtp_experts": "source",
+        "mtp_experts_start_layer": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_tp4_ep4_is_the_fused_first_boot_layout():
+    plan = plan_deepseek_v41()
+    assert plan.tensor_parallel_size == 4
+    assert plan.expert_parallel is True
+    assert plan.moe_tensor_parallel_size == 1
+    assert plan.expert_parallel_size == 4
+    assert plan.global_experts == 384
+    assert plan.local_experts == 96
+    assert plan.hidden_size == 5120
+    assert plan.intermediate_size_per_rank == 2304
+    assert plan.top_k == 6
+    assert plan.exllamav3_fused_candidate is True
+    assert plan.native_p2b_candidate is False
+    assert plan.preferred_first_boot_backend == "exllamav3"
+
+
+def test_pure_tp4_exposes_the_576_wide_problem():
+    plan = plan_deepseek_v41(expert_parallel=False)
+    assert plan.moe_tensor_parallel_size == 4
+    assert plan.expert_parallel_size == 1
+    assert plan.local_experts == 384
+    assert plan.intermediate_size_per_rank == 576
+    assert plan.exllamav3_fused_candidate is False
+    assert plan.native_p2b_candidate is False
+    assert plan.preferred_first_boot_backend == "loop"
+
+
+def test_source_quantization_traits_surface_v41_mxfp8_block_shape():
+    config = _v41_config()
+    assert source_weight_block_size(config) == [32, 32]
+    assert is_deepseek_v41_source_quant(config) is True
+
+
+def test_source_quantization_rejects_non_v41_delegate_shape():
+    config = _v41_config(
+        non_routed_quantization={
+            "quant_method": "deepseek_v4_fp8",
+            "weight_block_size": [128, 128],
+        }
+    )
+    assert source_weight_block_size(config) == [128, 128]
+    assert is_deepseek_v41_source_quant(config) is False
+
+
+def test_dspark_source_delegation_can_be_inferred_from_128_expert_stage():
+    config = _v41_config()
+    assert should_delegate_dspark_source(
+        config,
+        prefix="model.layers.40.ffn.experts",
+        global_num_experts=128,
+    ) is True
+    assert should_delegate_dspark_source(
+        config,
+        prefix="model.layers.39.ffn.experts",
+        global_num_experts=384,
+    ) is False
+
+
+def test_explicit_dspark_start_layer_remains_authoritative():
+    config = _v41_config(mtp_experts_start_layer=40)
+    assert should_delegate_dspark_source(
+        config,
+        prefix="model.layers.39.ffn.experts",
+        global_num_experts=128,
+    ) is False
+    assert should_delegate_dspark_source(
+        config,
+        prefix="model.layers.40.ffn.experts",
+        global_num_experts=128,
+    ) is True
+
+
+def test_dspark_inference_fails_closed_without_source_request():
+    config = _v41_config(mtp_experts="exl3")
+    assert should_delegate_dspark_source(
+        config,
+        prefix="model.layers.40.ffn.experts",
+        global_num_experts=128,
+    ) is False
+
+
+def test_installer_surfaces_outer_weight_block_size_and_is_idempotent():
+    class FakeConfig:
+        def __init__(self):
+            self.non_routed_quantization = {
+                "quant_method": "deepseek_v4_fp8",
+                "weight_block_size": [32, 32],
+            }
+
+        def get_quant_method(self, layer, prefix):
+            return None
+
+    module = SimpleNamespace(Exl3Config=FakeConfig)
+    install_deepseek_v41_compat(module)
+    install_deepseek_v41_compat(module)
+
+    config = FakeConfig()
+    assert config.weight_block_size == [32, 32]
+    assert config.has_blocked_weights() is True
+    assert module._vllm_exl3_v41_compat_installed is True
+
+
+def test_plan_rejects_non_divisible_expert_layout():
+    with pytest.raises(ValueError, match="global_experts"):
+        plan_deepseek_v41(global_experts=385)

--- a/tests/test_native_moe_contract.py
+++ b/tests/test_native_moe_contract.py
@@ -34,6 +34,9 @@ def test_native_geometry_accepts_tp1_tp2_and_clipping(intermediate, bits, limit)
      ((1, 4096), True, 2048, 4, math.inf)],
 )
 def test_native_geometry_retains_unsupported_guards(shape, cuda, intermediate, bits, limit):
+    # This is the legacy/default Python geometry policy. DeepSeek V4.1's ABI-3
+    # 5120x2304 extension path is installed separately by plugin registration
+    # and remains opt-in until its GB10 qualification completes.
     x = SimpleNamespace(shape=shape, is_cuda=cuda, dim=lambda: len(shape))
     layer = SimpleNamespace(_exl3_intermediate_local=intermediate, _exl3_k=bits)
     assert not exl3._native_moe_dimensions_supported(x, layer, [{}], limit)
@@ -44,7 +47,7 @@ def native_cuda():
     if not torch.cuda.is_available():
         pytest.skip("CUDA required for native MoE numerical checks")
     extension = pytest.importorskip("vllm_exl3_c")
-    assert getattr(extension, "P2B_MOE_ABI_VERSION", 1) >= 2, "rebuild vllm_exl3_c for MoE ABI 2"
+    assert getattr(extension, "P2B_MOE_ABI_VERSION", 1) >= 2, "rebuild vllm_exl3_c for MoE ABI 2+"
     return extension
 
 
@@ -148,6 +151,80 @@ def test_native_moe_clipping_width_and_graph_parity(native_cuda, bits, intermedi
     assert storage
 
 
+def test_native_moe_v41_5120x2304_numerical_parity(native_cuda, monkeypatch):
+    """Representative ABI-3 parity gate for one full V4.1 EP expert geometry."""
+    if getattr(native_cuda, "P2B_MOE_ABI_VERSION", 0) < 3:
+        pytest.skip("rebuild vllm_exl3_c for dynamic-geometry MoE ABI 3")
+
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+    torch.manual_seed(41)
+    device = torch.device("cuda")
+    bits = 2
+    hidden = 5120
+    intermediate = 2304
+
+    def projection(in_features, out_features, output_scale):
+        trellis = torch.randint(
+            -32768,
+            32767,
+            (in_features // 16, out_features // 16, 16 * bits),
+            dtype=torch.int16,
+        )
+        suh = torch.full((in_features,), 1.0 / 64, dtype=torch.float16)
+        svh = torch.full((out_features,), output_scale, dtype=torch.float16)
+        dense = native_cuda.dequant_trellis(trellis, suh, svh, bits, True).to(device).float()
+        storage = (trellis.to(device), suh.to(device), svh.to(device))
+        ptrs = [
+            torch.tensor([tensor.data_ptr()], dtype=torch.int64, device=device)
+            for tensor in storage
+        ]
+        return storage, ptrs, dense
+
+    gate_storage, gate_ptrs, gate_dense = projection(hidden, intermediate, 4.0)
+    up_storage, up_ptrs, up_dense = projection(hidden, intermediate, 4.0)
+    down_storage, down_ptrs, down_dense = projection(intermediate, hidden, 1.0)
+    storage = (gate_storage, up_storage, down_storage)
+    ptrs = gate_ptrs + up_ptrs + down_ptrs
+
+    x = torch.randn(1, hidden, dtype=torch.float16, device=device)
+    ids = torch.zeros(1, dtype=torch.int32, device=device)
+    weights = torch.ones(1, dtype=torch.float16, device=device)
+    out = torch.empty_like(x)
+    limit = 10.0
+
+    g = (x.float() @ gate_dense).half().float().clamp(max=limit)
+    u = (x.float() @ up_dense).half().float().clamp(min=-limit, max=limit)
+    h = (torch.nn.functional.silu(g) * u).half()
+    expected = (h.float() @ down_dense).half().float()
+
+    native_cuda.p2b_fused_moe(
+        x,
+        out,
+        *ptrs,
+        ids,
+        weights,
+        bits,
+        bits,
+        bits,
+        True,
+        intermediate,
+        limit,
+    )
+    torch.cuda.synchronize()
+
+    actual = out.float()
+    assert torch.isfinite(actual).all()
+    relative_error = (actual - expected).norm() / expected.norm().clamp_min(1e-8)
+    assert relative_error < 0.01, f"relative error: {relative_error.item()}"
+    torch.testing.assert_close(
+        actual,
+        expected,
+        rtol=0.01,
+        atol=0.01 * expected.abs().max().item(),
+    )
+    assert storage
+
+
 @pytest.mark.parametrize("bad", ["rows", "width", "negative_limit", "nan_limit", "strided_pointers"])
 def test_native_moe_rejects_unsafe_calls_before_launch(native_cuda, bad):
     x = torch.zeros(1, 4096, dtype=torch.float16, device="cuda")
@@ -160,7 +237,7 @@ def test_native_moe_rejects_unsafe_calls_before_launch(native_cuda, bad):
     if bad == "rows":
         x = x.repeat(2, 1)
     elif bad == "width":
-        width = 1536
+        width = 1537
     elif bad == "negative_limit":
         limit = -1.0
     elif bad == "nan_limit":

--- a/tools/qualify_deepseek_v41.py
+++ b/tools/qualify_deepseek_v41.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Preflight DeepSeek V4.1 EXL3 metadata and the recommended TP4+EP4 layout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from vllm_exl3.deepseek_v41 import (
+    is_deepseek_v41_source_quant,
+    plan_deepseek_v41,
+    source_weight_block_size,
+)
+
+
+def _load_quant_config(path: Path) -> dict:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("config must contain a JSON object")
+    quant = raw.get("quantization_config", raw)
+    if not isinstance(quant, dict):
+        raise ValueError("quantization_config must be an object")
+    return quant
+
+
+def inspect_config(quant: dict) -> dict[str, object]:
+    config = SimpleNamespace(**quant)
+    source = quant.get("non_routed_quantization")
+    source = source if isinstance(source, dict) else {}
+    issues: list[str] = []
+
+    if str(quant.get("quant_method", "")).lower() != "exl3":
+        issues.append("outer quant_method is not exl3")
+    if quant.get("mtp_experts") != "source":
+        issues.append("mtp_experts should be 'source' for the first V4.1 DSpark boot")
+    if not is_deepseek_v41_source_quant(config):
+        issues.append(
+            "non_routed_quantization must identify deepseek_v4_fp8 with weight_block_size [32, 32]"
+        )
+
+    return {
+        "ok": not issues,
+        "issues": issues,
+        "outer_quant_method": quant.get("quant_method"),
+        "bits": quant.get("bits"),
+        "codebook": quant.get("codebook"),
+        "scope": quant.get("scope"),
+        "mtp_experts": quant.get("mtp_experts"),
+        "mtp_experts_start_layer": quant.get("mtp_experts_start_layer"),
+        "source_quant_method": source.get("quant_method"),
+        "source_weight_block_size": source_weight_block_size(config),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "config",
+        nargs="?",
+        type=Path,
+        help="model config.json or a JSON file containing quantization_config",
+    )
+    parser.add_argument(
+        "--pure-tp",
+        action="store_true",
+        help="show the non-recommended pure-TP4 MoE layout instead of TP4+EP4",
+    )
+    args = parser.parse_args()
+
+    report: dict[str, object] = {
+        "layout": plan_deepseek_v41(expert_parallel=not args.pure_tp).to_dict(),
+    }
+    if args.config is not None:
+        report["pack"] = inspect_config(_load_quant_config(args.config))
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    pack = report.get("pack")
+    return 0 if not isinstance(pack, dict) or bool(pack.get("ok")) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Add the serving-side compatibility and first native-kernel path for `deepseek-ai/DeepSeek-V4.1-Flash` on four DGX Sparks without forking the V4.1 architecture into `vllm-exl3`.

The recommended topology is **TP4 overall + EP4 for routed MoE**. Under vLLM expert parallelism this keeps complete experts on each rank: 384 routed experts become 96 local experts per Spark at the full `5120 x 2304` expert shape. That avoids pure TP4's 384-expert/rank + 576-wide intermediate path.

## Changes

- Add `vllm_exl3.deepseek_v41` policy/helpers.
- Surface delegated V4.1 source `weight_block_size=[32,32]` through the outer `Exl3Config` so architecture-level MXFP8 scale/layout probes see the same traits used by dense-layer delegation.
- Add guarded source delegation for V4.1's 128-expert DSpark blocks when `mtp_experts=source` is declared without a numeric start-layer boundary.
- Add `plan_deepseek_v41()` with explicit TP4+EP4 vs pure-TP4 diagnostics.
- Add V4.1 information to `runtime_diagnostics()`.
- Generalize the existing cooperative native p2b MoE CUDA wrapper from hard-coded `4096 x {1024,2048}` geometry to positive 128-aligned hidden/intermediate dimensions. The CUDA kernel body was already dimension-driven.
- Bump `P2B_MOE_ABI_VERSION` to **3** for dynamic geometry.
- Keep V4.1 native p2b dispatch **default-off** behind `VLLM_EXL3_V41_NATIVE_MOE=1` and require ABI >= 3, so the correctness-first four-Spark boot can use ExLlamaV3 fused experts and the native path can be enabled as a controlled A/B.
- Add a CUDA numerical parity test for representative V4.1 `5120 x 2304` K2 geometry, plus CPU tests for the env gate and stale-ABI fail-closed behavior.
- Add `tools/qualify_deepseek_v41.py` for pack/config preflight.
- Add `docs/DEEPSEEK_V41_TP4_EP4.md` with the first-boot contract, pack metadata, DSpark policy and hardware qualification sequence.

## Deliberate scope boundary

This PR does **not** copy or reimplement DeepSeek V4.1 architecture, sparse attention, Lightning Indexer, Engram, Hyper-Connections, vision, DSpark execution, DeepSelect or DeepJIT. Those remain owned by vLLM/DeepSeek.

The ABI-3 native geometry is an **experimental hardware candidate**, not a performance claim. It must pass the new GPU numerical test and a same-checkpoint GB10 A/B before it can become a default for V4.1.

## Validation

GitHub CI on the first complete candidate passed all five jobs: Python compilation, unit/attribution suite, documentation integrity, aarch64 ExLlamaV3 patch verification, and wheel/sdist packaging. Subsequent test-only hardening keeps the same CPU behavior and adds an explicit V4.1 native gate/ABI test; CI is the source of truth for the latest head.

Required hardware gate before merge/release:

1. Build `vllm_exl3_c` for SM121 and verify ABI 3.
2. Run the `5120 x 2304` CUDA numerical parity test.
3. Bring up TP4+EP4 with ExLlamaV3 fused experts first.
4. A/B `VLLM_EXL3_V41_NATIVE_MOE=1` with the same checkpoint/prompts.
5. Add source-native DSpark-5, then CUDA graphs, context scaling and vision/tools one variable at a time.

AI assistance was used for implementation and research. The new compatibility layer is independently implemented against this repository's existing interfaces and public upstream behavior; it does not vendor the new DeepSeek repositories.