### PR TITLE
fix: GB10 build compat and opt-in diagnostic shape handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,15 @@ from setuptools import setup
 
 ROOT = Path(__file__).resolve().parent
 
+def _src(name):
+    """Return a source path relative to setup.py for setuptools >=77.
+    
+    setuptools >=77 rejects absolute paths in Extension() sources
+    but allows them in include_dirs. This helper relativizes only
+    the source file paths against the setup.py directory.
+    """
+    return str((ROOT / "csrc" / name).relative_to(ROOT))
+
 ext_modules = []
 cmdclass = {}
 
@@ -44,12 +53,12 @@ if os.environ.get("VLLM_EXL3_NO_CUDA", "0") != "1":
             CUDAExtension(
                 name="vllm_exl3_c",
                 sources=[
-                    str(ROOT / "csrc" / "bindings.cpp"),
-                    str(ROOT / "csrc" / "exl3_gemv.cu"),
-                    str(ROOT / "csrc" / "p2b_batched.cu"),
-                    str(ROOT / "csrc" / "p2b_moe.cu"),
-                    str(ROOT / "csrc" / "exl3_gemm.cu"),
-                    str(ROOT / "csrc" / "exl3_fat_gemm.cu"),
+                    _src("bindings.cpp"),
+                    _src("exl3_gemv.cu"),
+                    _src("p2b_batched.cu"),
+                    _src("p2b_moe.cu"),
+                    _src("exl3_gemm.cu"),
+                    _src("exl3_fat_gemm.cu"),
                 ],
                 include_dirs=include_dirs,
                 extra_compile_args={

--- a/src/vllm_exl3/exl3.py
+++ b/src/vllm_exl3/exl3.py
@@ -1987,20 +1987,27 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     f"VLLM_EXL3_ALLOW_SHAPE_MISMATCH=1 for diagnostic "
                     f"loading with partial weight copy."
                 )
+            if dest.ndim != sharded.ndim:
+                # Rank mismatches cannot be coordinate-mapped; reject before
+                # zero-filling so a failed load leaves the destination intact.
+                raise RuntimeError(
+                    f"EXL3 diagnostic load requires matching rank for "
+                    f"{weight_name} shard={shard_id} expert={expert_id}: "
+                    f"dest {dest.ndim}D {tuple(dest.shape)} vs loaded "
+                    f"{sharded.ndim}D {tuple(sharded.shape)}."
+                )
             logger.warning(
                 "EXL3 shape mismatch (DIAGNOSTIC) %s shard=%s expert=%s: "
-                "dest %s != loaded %s — zero-filling, copying overlap. "
-                "Model outputs WILL be incorrect.",
+                "dest %s != loaded %s — zero-filling, coordinate-copying "
+                "per-dimension overlap. Model outputs WILL be incorrect.",
                 weight_name, shard_id, expert_id,
                 tuple(dest.shape), tuple(sharded.shape),
             )
-            if sharded.numel() < dest.numel():
-                dest.zero_()
-                n = min(sharded.numel(), dest.numel())
-                dest.view(-1)[:n] = sharded.contiguous().view(-1)[:n].to(dest.dtype)
-            elif sharded.numel() > dest.numel():
-                sharded = sharded.contiguous().view(-1)[:dest.numel()].reshape(dest.shape)
-                dest.copy_(sharded)
+            dest.zero_()
+            slices = tuple(
+                slice(0, min(d, s)) for d, s in zip(dest.shape, sharded.shape)
+            )
+            dest[slices].copy_(sharded[slices].to(dest.dtype))
             return True if return_success else None
         dest.copy_(sharded)
         return True if return_success else None

--- a/src/vllm_exl3/exl3.py
+++ b/src/vllm_exl3/exl3.py
@@ -1978,11 +1978,30 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             raise ValueError(f"unknown EXL3 shard_id={shard_id}")
 
         if tuple(dest.shape) != tuple(sharded.shape):
-            raise RuntimeError(
-                f"EXL3 load shape mismatch {weight_name} shard={shard_id} "
-                f"expert={expert_id}: dest {tuple(dest.shape)} != "
-                f"loaded {tuple(sharded.shape)}"
+            import os as _os
+            if _os.environ.get("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "0") != "1":
+                raise RuntimeError(
+                    f"EXL3 load shape mismatch {weight_name} shard={shard_id} "
+                    f"expert={expert_id}: dest {tuple(dest.shape)} != "
+                    f"loaded {tuple(sharded.shape)}. Set "
+                    f"VLLM_EXL3_ALLOW_SHAPE_MISMATCH=1 for diagnostic "
+                    f"loading with partial weight copy."
+                )
+            logger.warning(
+                "EXL3 shape mismatch (DIAGNOSTIC) %s shard=%s expert=%s: "
+                "dest %s != loaded %s — zero-filling, copying overlap. "
+                "Model outputs WILL be incorrect.",
+                weight_name, shard_id, expert_id,
+                tuple(dest.shape), tuple(sharded.shape),
             )
+            if sharded.numel() < dest.numel():
+                dest.zero_()
+                n = min(sharded.numel(), dest.numel())
+                dest.view(-1)[:n] = sharded.contiguous().view(-1)[:n].to(dest.dtype)
+            elif sharded.numel() > dest.numel():
+                sharded = sharded.contiguous().view(-1)[:dest.numel()].reshape(dest.shape)
+                dest.copy_(sharded)
+            return True if return_success else None
         dest.copy_(sharded)
         return True if return_success else None
 

--- a/tests/test_loader_parity.py
+++ b/tests/test_loader_parity.py
@@ -119,3 +119,175 @@ def test_qkv_loader_replicated_kv_heads_uses_shard_specific_tp() -> None:
     loaded_svh = torch.arange(128, dtype=torch.float16)
     svh_loader(svh, loaded_svh, loaded_shard_id="k")
     torch.testing.assert_close(svh[512:640], loaded_svh)
+
+
+def _mismatch_param(dest_shape: tuple[int, ...]) -> torch.nn.Parameter:
+    """w1 slot-0 parameter whose destination slice has ``dest_shape``."""
+    param = torch.nn.Parameter(
+        torch.full((1, 2, *dest_shape), 7, dtype=torch.float32),
+        requires_grad=False,
+    )
+    param._exl3_owner = _MoEOwner()
+    return param
+
+
+def test_shape_mismatch_raises_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the opt-in env var a mismatched load must hard-fail untouched."""
+    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "0")
+    param = _mismatch_param((3, 4))
+    method = object.__new__(exl3.Exl3MoEMethod)
+
+    with pytest.raises(RuntimeError, match="shape mismatch"):
+        method._load_exl3(
+            param,
+            torch.arange(8, dtype=torch.float32).reshape(2, 4),
+            "experts.w13_trellis",
+            shard_id="w1",
+            expert_id=0,
+            return_success=True,
+        )
+
+    assert (param.data[0, 0] == 7).all()
+
+
+def test_diagnostic_mode_source_smaller_zero_fills_and_coordinate_copies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in padding: overlap is coordinate-copied, the tail zero-filled."""
+    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
+    param = _mismatch_param((3, 4))
+    src = torch.arange(8, dtype=torch.float32).reshape(2, 4) + 1
+    method = object.__new__(exl3.Exl3MoEMethod)
+
+    result = method._load_exl3(
+        param, src, "experts.w13_trellis",
+        shard_id="w1", expert_id=0, return_success=True,
+    )
+
+    assert result is True
+    torch.testing.assert_close(param.data[0, 0, :2], src)
+    assert (param.data[0, 0, 2:] == 0).all()
+
+
+def test_diagnostic_mode_source_larger_coordinate_trims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in trimming: only the leading per-dimension overlap is kept."""
+    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
+    param = _mismatch_param((2, 4))
+    src = torch.arange(15, dtype=torch.float32).reshape(3, 5) + 1
+    method = object.__new__(exl3.Exl3MoEMethod)
+
+    result = method._load_exl3(
+        param, src, "experts.w13_trellis",
+        shard_id="w1", expert_id=0, return_success=True,
+    )
+
+    assert result is True
+    torch.testing.assert_close(param.data[0, 0], src[:2, :4])
+
+
+def test_diagnostic_mode_equal_numel_keeps_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Equal-numel/different-shape: rows must not be packed across rows.
+
+    A flattened prefix copy would fill ``dest[2]`` from ``src[1]``'s tail;
+    the coordinate copy leaves the non-overlapping row zero. The source is
+    deliberately non-contiguous with 12 elements, like the destination.
+    """
+    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
+    param = _mismatch_param((3, 4))
+    src = (torch.arange(24, dtype=torch.float32).reshape(4, 6) + 1)[::2]
+    assert not src.is_contiguous()
+    assert tuple(src.shape) == (2, 6)
+    method = object.__new__(exl3.Exl3MoEMethod)
+
+    method._load_exl3(
+        param, src, "experts.w13_trellis", shard_id="w1", expert_id=0,
+    )
+
+    torch.testing.assert_close(param.data[0, 0, :2], src[:, :4])
+    assert (param.data[0, 0, 2:] == 0).all()
+
+
+def test_diagnostic_mode_dtype_converted_on_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in copy narrows the source dtype to the destination dtype."""
+    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
+    param = torch.nn.Parameter(
+        torch.full((1, 2, 3, 4), 7, dtype=torch.float16), requires_grad=False
+    )
+    param._exl3_owner = _MoEOwner()
+    src = torch.arange(8, dtype=torch.float32).reshape(2, 4) + 1
+    method = object.__new__(exl3.Exl3MoEMethod)
+
+    method._load_exl3(
+        param, src, "experts.w13_trellis", shard_id="w1", expert_id=0,
+    )
+
+    torch.testing.assert_close(
+        param.data[0, 0, :2], src.to(torch.float16), rtol=0, atol=0
+    )
+    assert (param.data[0, 0, 2:] == 0).all()
+
+
+def test_diagnostic_mode_ndim_mismatch_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rank mismatches stay a hard error even in diagnostic mode."""
+    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
+    param = _mismatch_param((3, 4))
+    method = object.__new__(exl3.Exl3MoEMethod)
+
+    with pytest.raises(RuntimeError, match="matching rank"):
+        method._load_exl3(
+            param,
+            torch.arange(12, dtype=torch.float32).reshape(3, 4, 1),
+            "experts.w13_trellis",
+            shard_id="w1",
+            expert_id=0,
+            return_success=True,
+        )
+
+    assert (param.data[0, 0] == 7).all()
+
+
+def test_return_success_only_in_diagnostic_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mismatched loads report success only with the explicit opt-in."""
+    param = _mismatch_param((3, 4))
+    mismatched = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    method = object.__new__(exl3.Exl3MoEMethod)
+
+    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
+    assert method._load_exl3(
+        param, mismatched, "experts.w13_trellis",
+        shard_id="w1", expert_id=0, return_success=True,
+    )
+    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "0")
+    with pytest.raises(RuntimeError, match="shape mismatch"):
+        method._load_exl3(
+            param, mismatched, "experts.w13_trellis",
+            shard_id="w1", expert_id=0, return_success=True,
+        )
+
+    # Matching shapes succeed regardless of the diagnostic opt-in.
+    matched_param = torch.nn.Parameter(
+        torch.zeros(1, 2, 2, 4, dtype=torch.float32), requires_grad=False
+    )
+    matched_param._exl3_owner = _MoEOwner()
+    matched = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    assert method._load_exl3(
+        matched_param, matched, "experts.w13_trellis",
+        shard_id="w1", expert_id=0, return_success=True,
+    )
+    assert (
+        method._load_exl3(
+            matched_param, matched, "experts.w13_trellis",
+            shard_id="w1", expert_id=0,
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

Two fixes for building and running vllm-exl3 on NVIDIA DGX Spark (GB10, sm_121, aarch64):

### 1. setup.py: setuptools >=77 compatibility

setuptools >=77 rejects absolute paths in `Extension()` sources. Both vllm-exl3 and ExLlamaV3 require >=77 for SPDX `pyproject.toml` license support, creating a catch-22.

**Fix:** Added a `_src()` helper that relativizes source paths against the setup.py directory using `.relative_to()`. Include directories remain absolute (setuptools doesn't check those).

### 2. exl3.py: Opt-in diagnostic loading for shape mismatches

When loading a TP4-sharded pack into an EP4-configured model (or vice versa), the existing `RuntimeError` prevents any diagnostics.

**Fix:** New env var `VLLM_EXL3_ALLOW_SHAPE_MISMATCH=1` enables diagnostic mode: logs a `WARNING`, zero-fills the destination, copies the overlapping region, and returns success. Default behavior is unchanged (hard fail).

This is explicitly **not** for production — outputs will be incorrect — but it unblocks pipeline debugging when the correct topology pack isn't yet available.

## Testing

Verified on 4× NVIDIA DGX Spark (GB10, sm_121, CUDA 13):
- ✅ Build passes with setuptools >=77
- ✅ ExLlamaV3 extension compiles and loads
- ✅ ABI 3 confirmed after build
- ✅ Diagnostic mode loads mixed-topology packs without crash
- ✅ Default (no env var) still raises RuntimeError

## Notes

- The `_src()` approach preserves backward compatibility: if setuptools <77 is used, relative paths work identically
- The shape mismatch gate is opt-in and logs prominently to prevent accidental use in production