### PR TITLE
integrate: mixed-K routed experts with qualification hardening

### DIFF
--- a/src/vllm_exl3/__init__.py
+++ b/src/vllm_exl3/__init__.py
@@ -109,12 +109,23 @@ def runtime_diagnostics():
         "tensor_level_mixed_k_within_layer": True,
         "heterogeneous_dispatch": "python_loop",
         "uniform_k_dispatch": "fused_when_available",
+        "cudagraph_qualified": False,
+        "recommended_first_boot": "eager",
+        "arena_prescan_placement_contract": "linear_contiguous_global_expert_ids",
+        "legacy_shape_overlap_diagnostic": False,
+        "legacy_shape_overlap_note": (
+            "The old opt-in partial-copy trellis diagnostic is superseded by exact-shape "
+            "per-expert trellis allocation. Non-trellis scale/marker shape mismatches "
+            "remain hard failures."
+        ),
         "note": (
             "K7/K8 are accepted for ExLlamaV3 execution. The custom native p2b "
             "path remains K2-K4. Routed experts store exact per-expert trellis "
             "shapes (including intra-expert w1/w2/w3 K disagreement). "
             "Heterogeneous packed K within a layer forces the LinearEXL3 "
-            "python_loop; uniform-K layers still use the fused fast path."
+            "python_loop; uniform-K layers still use the fused fast path. "
+            "The heterogeneous path is correctness-first and should remain eager "
+            "until CUDA-graph qualification is completed."
         ),
     }
     record["tp_geometry"] = {

--- a/src/vllm_exl3/__init__.py
+++ b/src/vllm_exl3/__init__.py
@@ -35,6 +35,7 @@ def register() -> None:
     from . import exl3
     from .deepseek_v41 import install_deepseek_v41_compat
     from .k78_compat import install_k78_config_compat
+    from .mixed_k_guard import install_mixed_k_prescan_guard
     from .runtime_policy import install_native_row_policy
     from .tp_geometry_compat import install_tp_geometry_compat
     from .uva_offload import install_uva_expert_validation
@@ -48,6 +49,11 @@ def register() -> None:
     # RoutedExperts.moe_config.moe_parallel_config. Resolve that before falling
     # back to process-wide TP state so EP ranks keep whole expert matrices.
     install_tp_geometry_compat(exl3)
+
+    # The low-memory mixed-K arena prescan assumes a contiguous linear expert
+    # range. Disable that optimization for non-linear placement/EPLB and let the
+    # authoritative vLLM loader mapping drive expert ownership instead.
+    install_mixed_k_prescan_guard(exl3)
 
     # Install model-family compatibility before runtime policy wrappers inspect
     # the quantization config. vLLM still owns the DeepSeek V4.1 architecture.
@@ -112,6 +118,9 @@ def runtime_diagnostics():
         "cudagraph_qualified": False,
         "recommended_first_boot": "eager",
         "arena_prescan_placement_contract": "linear_contiguous_global_expert_ids",
+        "arena_prescan_guard_installed": bool(
+            getattr(exl3, "_vllm_exl3_mixed_k_prescan_guard_installed", False)
+        ),
         "legacy_shape_overlap_diagnostic": False,
         "legacy_shape_overlap_note": (
             "The old opt-in partial-copy trellis diagnostic is superseded by exact-shape "

--- a/src/vllm_exl3/__init__.py
+++ b/src/vllm_exl3/__init__.py
@@ -103,12 +103,18 @@ def runtime_diagnostics():
         "k78_config_compat_installed": bool(
             getattr(exl3, "_vllm_exl3_k78_compat_installed", False)
         ),
-        "routed_allocation_scope": "one K per RoutedExperts transformer layer",
-        "tensor_level_mixed_k_within_layer": False,
+        "routed_allocation_scope": (
+            "per-expert exact trellis shapes; uniform-K layers keep fused path"
+        ),
+        "tensor_level_mixed_k_within_layer": True,
+        "heterogeneous_dispatch": "python_loop",
+        "uniform_k_dispatch": "fused_when_available",
         "note": (
             "K7/K8 are accepted for ExLlamaV3 execution. The custom native p2b "
-            "path remains K2-K4. Current vLLM routed allocation still requires "
-            "one K per RoutedExperts transformer layer."
+            "path remains K2-K4. Routed experts store exact per-expert trellis "
+            "shapes (including intra-expert w1/w2/w3 K disagreement). "
+            "Heterogeneous packed K within a layer forces the LinearEXL3 "
+            "python_loop; uniform-K layers still use the fused fast path."
         ),
     }
     record["tp_geometry"] = {

--- a/src/vllm_exl3/exl3.py
+++ b/src/vllm_exl3/exl3.py
@@ -24,9 +24,13 @@ work, Copyright (c) 2025 Turboderp, MIT. See THIRD_PARTY_NOTICES.md.
 
 from __future__ import annotations
 
+import gc
 import importlib
+import json
 import math
 import os
+import time
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import re
@@ -424,6 +428,435 @@ def filter_speculative_candidates(
     return mask, kept_counts
 
 
+def _exl3_trellis_arena_enabled() -> bool:
+    """Contiguous per-shape trellis arenas (default ON). Set 0 to use legacy allocs."""
+    return os.environ.get("VLLM_EXL3_TRELLIS_ARENA", "1") != "0"
+
+
+def _exl3_mem_waterfall_enabled() -> bool:
+    return os.environ.get("VLLM_EXL3_MEM_WATERFALL", "0") == "1"
+
+
+def _read_proc_meminfo_gib(*keys: str) -> dict[str, float]:
+    out: dict[str, float] = {}
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as fh:
+            wanted = set(keys)
+            for line in fh:
+                name, _, rest = line.partition(":")
+                if name in wanted:
+                    out[name] = int(rest.strip().split()[0]) / (1024.0 * 1024.0)
+    except OSError:
+        pass
+    return out
+
+
+def _exl3_mem_snapshot(tag: str, layer: Any | None = None) -> dict[str, Any]:
+    """Host + process + torch CUDA memory snapshot for materialization tracing."""
+    snap: dict[str, Any] = {"tag": tag, "ts": time.time()}
+    snap.update(_read_proc_meminfo_gib("MemAvailable", "AnonPages", "Cached"))
+    try:
+        with open("/proc/self/status", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    snap["VmRSS_GiB"] = int(line.split()[1]) / (1024.0 * 1024.0)
+                elif line.startswith("VmSize:"):
+                    snap["VmSize_GiB"] = int(line.split()[1]) / (1024.0 * 1024.0)
+    except OSError:
+        pass
+    try:
+        with open("/proc/self/smaps_rollup", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("Pss:"):
+                    snap["Pss_GiB"] = int(line.split()[1]) / (1024.0 * 1024.0)
+                    break
+    except OSError:
+        pass
+    if _TORCH_AVAILABLE and torch is not None and torch.cuda.is_available():
+        try:
+            snap["cuda_allocated_GiB"] = torch.cuda.memory_allocated() / (1024.0**3)
+            snap["cuda_reserved_GiB"] = torch.cuda.memory_reserved() / (1024.0**3)
+        except Exception:
+            pass
+    if layer is not None:
+        snap["trellis_storage_count"] = _count_trellis_storages(layer)
+        snap["trellis_final_bytes"] = _trellis_nbytes(layer)
+        staging = getattr(layer, "_exl3_trellis_staging", None)
+        if staging:
+            snap["trellis_staging_bytes"] = sum(
+                int(t.numel()) * int(t.element_size())
+                for proj_map in staging.values()
+                for t in proj_map.values()
+                if t is not None
+            )
+    path = os.environ.get("VLLM_EXL3_MEM_WATERFALL_PATH", "")
+    if path:
+        try:
+            with open(path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(snap, sort_keys=True) + "\n")
+        except OSError:
+            pass
+    return snap
+
+
+def _count_trellis_storages(layer: Any) -> int:
+    """Unique trellis backing storages (arena tensors when present)."""
+    if not _TORCH_AVAILABLE or torch is None:
+        return 0
+    ptrs: set[int] = set()
+    arena_lists = (
+        getattr(layer, "_exl3_gate_trellis_arenas", None),
+        getattr(layer, "_exl3_up_trellis_arenas", None),
+        getattr(layer, "_exl3_down_trellis_arenas", None),
+    )
+    has_arenas = False
+    for arenas in arena_lists:
+        if not arenas:
+            continue
+        has_arenas = True
+        for arena in arenas:
+            try:
+                ptrs.add(int(arena.untyped_storage().data_ptr()))
+            except Exception:
+                continue
+    if has_arenas:
+        return len(ptrs)
+    for name in ("gate_trellis", "up_trellis", "down_trellis"):
+        plist = getattr(layer, name, None)
+        if plist is None:
+            continue
+        for p in plist:
+            if p is None or int(getattr(p, "numel", lambda: 0)()) == 0:
+                continue
+            try:
+                ptrs.add(int(p.untyped_storage().data_ptr()))
+            except Exception:
+                continue
+    return len(ptrs)
+
+
+def _trellis_nbytes(layer: Any) -> int:
+    total = 0
+    for name in ("gate_trellis", "up_trellis", "down_trellis"):
+        plist = getattr(layer, name, None)
+        if plist is None:
+            continue
+        for p in plist:
+            if p is None or int(getattr(p, "numel", lambda: 0)()) == 0:
+                continue
+            total += int(p.numel()) * int(p.element_size())
+    # Arenas may be counted twice if we also sum views; prefer arena bytes when present.
+    arena_bytes = 0
+    for aname in (
+        "_exl3_gate_trellis_arenas",
+        "_exl3_up_trellis_arenas",
+        "_exl3_down_trellis_arenas",
+    ):
+        for arena in getattr(layer, aname, []) or []:
+            arena_bytes += int(arena.numel()) * int(arena.element_size())
+    return arena_bytes if arena_bytes else total
+
+
+def _proj_from_shard_id(shard_id: str) -> str:
+    if shard_id == "w1":
+        return "gate"
+    if shard_id == "w3":
+        return "up"
+    if shard_id == "w2":
+        return "down"
+    raise ValueError(f"unknown EXL3 shard_id={shard_id}")
+
+
+def _try_prescan_trellis_shapes(
+    layer: Any,
+    num_experts: int,
+) -> dict[str, dict[int, tuple[int, ...]]] | None:
+    """Header-only shape scan from the on-disk checkpoint (no tensor materialize).
+
+    Uses ``VLLM_ENGRAM_MODEL_DIR`` / ``VLLM_EXL3_MODEL_DIR`` and the layer's
+    ``layer_name``/``prefix`` to locate ``layers.N.ffn.experts.*`` trellis keys.
+    Local expert ids map linearly onto a global contiguous block when
+    ``layer.starting_expert_offset`` / EP metadata is present; otherwise assume
+    local id == global id (offline tests).
+    """
+    model_dir = os.environ.get("VLLM_ENGRAM_MODEL_DIR") or os.environ.get(
+        "VLLM_EXL3_MODEL_DIR"
+    )
+    if not model_dir:
+        return None
+    try:
+        from safetensors import safe_open
+    except Exception:
+        return None
+    index_path = os.path.join(model_dir, "model.safetensors.index.json")
+    if not os.path.isfile(index_path):
+        return None
+    try:
+        with open(index_path, encoding="utf-8") as fh:
+            weight_map = json.load(fh).get("weight_map", {})
+    except Exception:
+        return None
+    layer_name = str(
+        getattr(layer, "layer_name", None)
+        or getattr(layer, "prefix", None)
+        or ""
+    )
+    # Expect ...layers.N.ffn.experts or layers.N
+    import re as _re
+
+    m = _re.search(r"layers\.(\d+)", layer_name)
+    if not m:
+        return None
+    layer_id = int(m.group(1))
+    offset = int(
+        getattr(layer, "starting_expert_offset", None)
+        or getattr(layer, "expert_id_offset", None)
+        or 0
+    )
+    # EP linear placement: local e <-> global offset+e
+    prefix = f"layers.{layer_id}.ffn.experts."
+    shapes: dict[str, dict[int, tuple[int, ...]]] = {
+        "gate": {},
+        "up": {},
+        "down": {},
+    }
+    proj_map = {"w1": "gate", "w3": "up", "w2": "down"}
+    # Gather keys per local expert.
+    for local_e in range(int(num_experts)):
+        global_e = offset + local_e
+        for wp, proj in proj_map.items():
+            key = f"{prefix}{global_e}.{wp}.trellis"
+            shard = weight_map.get(key)
+            if shard is None:
+                return None  # incomplete map; fall back to stage-pack
+            path = os.path.join(model_dir, shard)
+            try:
+                with safe_open(path, framework="pt") as f:
+                    shape = tuple(int(x) for x in f.get_slice(key).get_shape())
+            except Exception:
+                return None
+            shapes[proj][local_e] = shape
+    return shapes
+
+
+def prepare_trellis_arena_plan(
+    layer: Any,
+    shapes_by_proj: dict[str, dict[int, tuple[int, ...]]],
+) -> dict[str, Any]:
+    """Pre-allocate contiguous per-shape arenas and map expert_id -> slot.
+
+    ``shapes_by_proj`` maps proj in {gate,up,down} -> {expert_id: exact_shape}.
+    Subsequent ``_load_exl3`` trellis loads copy directly into the planned slot
+    (safetensors -> FINAL) without retaining a full-layer staging set.
+    """
+    if not _TORCH_AVAILABLE or torch is None:
+        raise RuntimeError("torch required for trellis arenas")
+    dest_device = layer.w13_suh.device
+    proj_to_plist = {
+        "gate": layer.gate_trellis,
+        "up": layer.up_trellis,
+        "down": layer.down_trellis,
+    }
+    proj_to_attr = {
+        "gate": "_exl3_gate_trellis_arenas",
+        "up": "_exl3_up_trellis_arenas",
+        "down": "_exl3_down_trellis_arenas",
+    }
+    plan: dict[str, dict[tuple[int, ...], dict[str, Any]]] = {}
+    eid_index: dict[str, dict[int, tuple[tuple[int, ...], int]]] = {
+        "gate": {},
+        "up": {},
+        "down": {},
+    }
+    stats: dict[str, Any] = {
+        "planned": True,
+        "arenas": {},
+        "allocations_after": 0,
+        "final_bytes": 0,
+        "temp_peak_bytes": 0,
+    }
+    for proj, plist in proj_to_plist.items():
+        by_shape: dict[tuple[int, ...], list[int]] = defaultdict(list)
+        for eid, shape in sorted((shapes_by_proj.get(proj) or {}).items()):
+            by_shape[tuple(int(x) for x in shape)].append(int(eid))
+        arenas: list[Parameter] = []
+        plan[proj] = {}
+        n_experts = int(len(plist))
+        for shape, eids in by_shape.items():
+            n = len(eids)
+            arena = torch.empty((n, *shape), dtype=torch.int16, device=dest_device)
+            meta = {
+                "arena": arena,
+                "eid_to_idx": {eid: i for i, eid in enumerate(eids)},
+            }
+            plan[proj][shape] = meta
+            for i, eid in enumerate(eids):
+                if not (0 <= eid < n_experts):
+                    raise RuntimeError(f"EXL3 arena plan expert out of range: {eid}")
+                view = arena[i]
+                new_p = Parameter(view, requires_grad=False)
+                new_p.weight_loader = getattr(plist[eid], "weight_loader", None)
+                new_p._exl3_owner = layer
+                plist[eid] = new_p
+                eid_index[proj][eid] = (shape, i)
+            arenas.append(Parameter(arena, requires_grad=False))
+            stats["arenas"].setdefault(proj, []).append(
+                {"shape": list(shape), "n": n, "bytes": int(arena.nbytes)}
+            )
+            stats["allocations_after"] += 1
+            stats["final_bytes"] += int(arena.nbytes)
+        setattr(layer, proj_to_attr[proj], arenas)
+    layer._exl3_trellis_arena_plan = plan
+    layer._exl3_trellis_eid_index = eid_index
+    layer._exl3_trellis_staging = {"gate": {}, "up": {}, "down": {}}
+    layer._exl3_trellis_arena_stats = stats
+    layer._exl3_trellis_temp_peak_bytes = 0
+    return stats
+
+
+def _direct_fill_trellis_slot(
+    layer: Any,
+    proj: str,
+    expert_id: int,
+    src: "torch.Tensor",
+) -> None:
+    """Copy one trellis into its pre-planned arena slot; drop ``src`` ASAP."""
+    eid_index = getattr(layer, "_exl3_trellis_eid_index", None)
+    plan = getattr(layer, "_exl3_trellis_arena_plan", None)
+    if not eid_index or not plan:
+        raise RuntimeError("EXL3 direct fill requires prepare_trellis_arena_plan")
+    if expert_id not in eid_index[proj]:
+        raise RuntimeError(
+            f"EXL3 arena plan missing {proj} expert={expert_id} shape={tuple(src.shape)}"
+        )
+    shape, idx = eid_index[proj][expert_id]
+    if tuple(int(x) for x in src.shape) != shape:
+        raise RuntimeError(
+            f"EXL3 arena slot shape mismatch {proj} expert={expert_id}: "
+            f"got {tuple(src.shape)} planned {shape}"
+        )
+    arena = plan[proj][shape]["arena"]
+    transient = int(src.numel()) * int(src.element_size())
+    layer._exl3_trellis_temp_peak_bytes = max(
+        int(getattr(layer, "_exl3_trellis_temp_peak_bytes", 0)), transient
+    )
+    if src.device == arena.device and src.dtype == torch.int16:
+        arena[idx].copy_(src if src.is_contiguous() else src.contiguous())
+    else:
+        arena[idx].copy_(
+            src.to(device=arena.device, dtype=torch.int16, non_blocking=False)
+        )
+
+
+def _pack_trellis_arenas(layer: Any) -> dict[str, Any]:
+    """Pack staged per-expert trellis tensors into contiguous per-shape arenas.
+
+    Each expert keeps an exact-shape view (no padding/truncation). Heterogeneous
+    K is preserved by grouping only equal shapes into the same arena.
+
+    Prefer ``prepare_trellis_arena_plan`` + direct fill to avoid holding a full
+    staging set beside the final arenas (UMA source+dest coexistence).
+    """
+    if not _TORCH_AVAILABLE or torch is None:
+        raise RuntimeError("torch required for trellis arenas")
+    # Already planned+filled: just report stats.
+    if getattr(layer, "_exl3_trellis_arena_plan", None) is not None:
+        stats = dict(getattr(layer, "_exl3_trellis_arena_stats", {}) or {})
+        stats["packed"] = True
+        stats["mode"] = "direct_plan"
+        stats["temp_peak_bytes"] = int(
+            getattr(layer, "_exl3_trellis_temp_peak_bytes", 0)
+        )
+        layer._exl3_trellis_arena_stats = stats
+        return stats
+
+    staging: dict[str, dict[int, torch.Tensor]] = getattr(
+        layer, "_exl3_trellis_staging", None
+    ) or {}
+    if not staging:
+        return {"packed": False, "reason": "no_staging"}
+
+    dest_device = layer.w13_suh.device
+    stats: dict[str, Any] = {
+        "packed": True,
+        "mode": "post_stage_pack",
+        "arenas": {},
+        "allocations_after": 0,
+        "final_bytes": 0,
+        "temp_peak_bytes": 0,
+    }
+    temp_bytes = 0
+    for proj_map in staging.values():
+        for t in proj_map.values():
+            temp_bytes += int(t.numel()) * int(t.element_size())
+    stats["temp_peak_bytes"] = temp_bytes
+
+    proj_to_plist = {
+        "gate": layer.gate_trellis,
+        "up": layer.up_trellis,
+        "down": layer.down_trellis,
+    }
+    proj_to_attr = {
+        "gate": "_exl3_gate_trellis_arenas",
+        "up": "_exl3_up_trellis_arenas",
+        "down": "_exl3_down_trellis_arenas",
+    }
+
+    for proj, plist in proj_to_plist.items():
+        by_shape: dict[tuple[int, ...], list[tuple[int, torch.Tensor]]] = defaultdict(
+            list
+        )
+        for eid, tensor in sorted((staging.get(proj) or {}).items()):
+            if tensor is None or int(tensor.numel()) == 0:
+                continue
+            if tensor.dtype != torch.int16:
+                tensor = tensor.to(dtype=torch.int16)
+            shape = tuple(int(x) for x in tensor.shape)
+            by_shape[shape].append((int(eid), tensor))
+
+        arenas: list[Parameter] = []
+        n_experts = int(len(plist))
+        for shape, items in by_shape.items():
+            n = len(items)
+            arena = torch.empty(
+                (n, *shape), dtype=torch.int16, device=dest_device
+            )
+            for i, (eid, src) in enumerate(items):
+                if not (0 <= eid < n_experts):
+                    raise RuntimeError(f"EXL3 arena expert id out of range: {eid}")
+                if src.device == dest_device and src.dtype == torch.int16:
+                    arena[i].copy_(src if src.is_contiguous() else src.contiguous())
+                else:
+                    arena[i].copy_(
+                        src.to(device=dest_device, dtype=torch.int16, non_blocking=False)
+                    )
+                view = arena[i]
+                new_p = Parameter(view, requires_grad=False)
+                new_p.weight_loader = getattr(plist[eid], "weight_loader", None)
+                new_p._exl3_owner = layer
+                plist[eid] = new_p
+                staging[proj].pop(eid, None)
+                del src
+            arenas.append(Parameter(arena, requires_grad=False))
+            stats["arenas"].setdefault(proj, []).append(
+                {"shape": list(shape), "n": n, "bytes": int(arena.nbytes)}
+            )
+            stats["allocations_after"] += 1
+            stats["final_bytes"] += int(arena.nbytes)
+            # Free host pages for this shape group before the next alloc on UMA.
+            gc.collect()
+        setattr(layer, proj_to_attr[proj], arenas)
+
+    layer._exl3_trellis_staging = {"gate": {}, "up": {}, "down": {}}
+    gc.collect()
+    if torch.cuda.is_available():
+        try:
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+    return stats
+
+
 def _narrow_tp(tensor: torch.Tensor, dim: int, tp_rank: int, tp_size: int) -> torch.Tensor:
     if tp_size <= 1:
         return tensor
@@ -704,7 +1137,7 @@ def build_exl3_fused_state(layer: torch.nn.Module, inners: list[dict[str, Any]])
     except Exception:
         exllamav3_ext = None
 
-    device = layer.w13_trellis.device
+    device = layer.w13_suh.device
     n_exp = len(inners)
     # Gate/up input rotations are immutable after load. Cache this compatibility
     # fact once so fat-prefill dispatch never calls torch.equal on CUDA tensors
@@ -1844,20 +2277,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "EXL3 trellis tiles are 16-wide; "
                 f"hidden={hidden_size} intermediate_local={intermediate_size_per_partition}"
             )
+        # Default/base K from config. Real DSV4.1 4.75bpw packs are mixed-K
+        # even within a single expert (w1/w2/w3 can differ). Trellis storage is
+        # therefore ragged and sized on load from the checkpoint tensor itself.
         k_words = self.bits * 16
         in_tiles = hidden_size // 16
         out_tiles = intermediate_size_per_partition // 16
 
         extra = {k: v for k, v in extra_weight_attrs.items() if k != "weight_loader"}
 
-        # w13_* : stacked [expert, {gate=0, up=1}, ...] so the stock
-        # expert_params_mapping (experts.w13_ + suffix) hits these names.
-        w13_trellis = Parameter(
-            torch.empty(
-                num_experts, 2, in_tiles, out_tiles, k_words, dtype=torch.int16
-            ),
-            requires_grad=False,
-        )
+        # Suh/svh/markers stay stacked (shape independent of packed K).
         w13_suh = Parameter(
             torch.empty(num_experts, 2, hidden_size, dtype=torch.float16),
             requires_grad=False,
@@ -1874,12 +2303,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         w13_mul1 = Parameter(
             torch.zeros(num_experts, 2, 1, dtype=torch.int32),
-            requires_grad=False,
-        )
-        w2_trellis = Parameter(
-            torch.empty(
-                num_experts, out_tiles, in_tiles, k_words, dtype=torch.int16
-            ),
             requires_grad=False,
         )
         w2_suh = Parameter(
@@ -1901,6 +2324,42 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             requires_grad=False,
         )
 
+        # Dummy named parameters so expert_params_mapping still resolves
+        # ``w13_trellis`` / ``w2_trellis``. Real trellis payloads live in the
+        # ragged ParameterLists below and are replaced with exact shapes on load.
+        w13_trellis = Parameter(torch.empty(0, dtype=torch.int16), requires_grad=False)
+        w2_trellis = Parameter(torch.empty(0, dtype=torch.int16), requires_grad=False)
+
+        gate_trellis = torch.nn.ParameterList(
+            [
+                Parameter(torch.empty(0, dtype=torch.int16), requires_grad=False)
+                for _ in range(num_experts)
+            ]
+        )
+        up_trellis = torch.nn.ParameterList(
+            [
+                Parameter(torch.empty(0, dtype=torch.int16), requires_grad=False)
+                for _ in range(num_experts)
+            ]
+        )
+        down_trellis = torch.nn.ParameterList(
+            [
+                Parameter(torch.empty(0, dtype=torch.int16), requires_grad=False)
+                for _ in range(num_experts)
+            ]
+        )
+        layer.gate_trellis = gate_trellis
+        layer.up_trellis = up_trellis
+        layer.down_trellis = down_trellis
+        # Staging for arena pack: exact per-expert tensors held briefly on host,
+        # then copied into contiguous per-shape arenas in process_weights.
+        layer._exl3_trellis_staging = {"gate": {}, "up": {}, "down": {}}
+        layer._exl3_gate_trellis_arenas = []
+        layer._exl3_up_trellis_arenas = []
+        layer._exl3_down_trellis_arenas = []
+        layer._exl3_trellis_arena_stats = {}
+        layer._exl3_trellis_alloc_count_before = 0
+
         packed = {
             "w13_trellis": w13_trellis,
             "w13_suh": w13_suh,
@@ -1918,13 +2377,47 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             set_weight_attrs(param, extra)
             param.weight_loader = self._load_exl3
             param._exl3_owner = layer
+        for plist in (gate_trellis, up_trellis, down_trellis):
+            for param in plist:
+                set_weight_attrs(param, extra)
+                param.weight_loader = self._load_exl3
+                param._exl3_owner = layer
         if hasattr(layer, "w13_weight") or hasattr(layer, "w2_weight"):
             raise RuntimeError("EXL3 create_weights must not allocate dense expert weights")
 
         layer._exl3_hidden_size = hidden_size
         layer._exl3_intermediate_local = intermediate_size_per_partition
-        layer._exl3_k_words = k_words
+        layer._exl3_in_tiles = in_tiles
+        layer._exl3_out_tiles = out_tiles
+        layer._exl3_k_words = k_words  # config default only; actual K is per-trellis
         layer._exl3_bits = self.bits
+        layer._exl3_mixed_k = False
+        layer._exl3_n_experts = int(num_experts)
+        # Linear EP placement offset for checkpoint prescan (local->global).
+        if not hasattr(layer, "starting_expert_offset"):
+            try:
+                from vllm.distributed.parallel_state import get_ep_group
+
+                ep = get_ep_group()
+                layer.starting_expert_offset = int(ep.rank) * int(num_experts)
+            except Exception:
+                layer.starting_expert_offset = 0
+        # Header-only shape scan (no allocation yet). Arenas are created on the
+        # first trellis load after the module has been moved to its exec device,
+        # so a later layer.to(device) cannot clone views apart.
+        layer._exl3_trellis_shapes_pending = None
+        if (
+            _exl3_trellis_arena_enabled()
+            and os.environ.get("VLLM_EXL3_ARENA_PRESCAN", "1") != "0"
+        ):
+            shapes = _try_prescan_trellis_shapes(layer, int(num_experts))
+            if shapes is not None:
+                layer._exl3_trellis_shapes_pending = shapes
+                logger.info(
+                    "EXL3 trellis arena PRESCAN shapes ready for %s experts "
+                    "(alloc deferred until first load)",
+                    num_experts,
+                )
         # vLLM's generic RoutedExperts.load_weights treats any 3-D checkpoint
         # tensor as fused stacked experts and unbinds it per expert; an EXL3
         # per-expert trellis is 3-D by construction. Route this layer's tensors
@@ -1953,68 +2446,214 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 return False if return_success else None
             expert_id = local_id
 
-        tp_rank, tp_size = _resolve_tp_geometry(owner, layer)
+        owner_mod = owner if owner is not None else getattr(param, "_exl3_owner", None)
+        tp_rank, tp_size = _resolve_tp_geometry(owner_mod, param)
         suffix = _suffix_from_mapped_name(weight_name)
-        loaded = loaded_weight.detach().contiguous()
+        # Avoid an early full-tensor .contiguous() copy. On GB10 UMA that
+        # transient host copy sits beside the eventual device payload and was
+        # observed to push MemAvailable under the 16 GiB abort cliff.
+        loaded = loaded_weight.detach()
         if suffix in ("mcg", "mul1"):
             # Codebook markers are scalars ([] or [1]); keep the value per expert
             # tensor so process_weights_after_loading can pick the codebook.
+            if owner_mod is None:
+                raise RuntimeError("EXL3 marker load missing owner module")
             if shard_id in ("w1", "w3"):
-                dest = param.data[expert_id, 0 if shard_id == "w1" else 1]
+                dest = getattr(owner_mod, "w13_" + suffix).data[
+                    expert_id, 0 if shard_id == "w1" else 1
+                ]
             elif shard_id == "w2":
-                dest = param.data[expert_id]
+                dest = getattr(owner_mod, "w2_" + suffix).data[expert_id]
             else:
                 raise ValueError(f"unknown EXL3 shard_id={shard_id}")
             dest.fill_(int(loaded.reshape(-1)[0].item()) if loaded.numel() else 0)
             return True if return_success else None
+
+        if suffix == "trellis":
+            # Exact checkpoint shape per expert. With arenas enabled, stage on
+            # host and pack into contiguous per-shape arenas later (views keep
+            # heterogeneous K / expert IDs). Legacy path allocates one Parameter
+            # per expert immediately.
+            if owner_mod is None:
+                raise RuntimeError("EXL3 trellis load missing owner module")
+            if _exl3_mem_waterfall_enabled():
+                _exl3_mem_snapshot("BEFORE_SOURCE", owner_mod)
+            if shard_id in ("w1", "w3"):
+                sharded = shard_exl3_col(loaded, suffix, tp_rank, tp_size)
+                plist = owner_mod.gate_trellis if shard_id == "w1" else owner_mod.up_trellis
+            elif shard_id == "w2":
+                sharded = shard_exl3_row(loaded, suffix, tp_rank, tp_size)
+                plist = owner_mod.down_trellis
+            else:
+                raise ValueError(f"unknown EXL3 shard_id={shard_id}")
+            if _exl3_mem_waterfall_enabled():
+                _exl3_mem_snapshot("AFTER_SOURCE_OPEN", owner_mod)
+            # Validate tile geometry against the layer's hidden/intermediate
+            # before paying for a device materialization.
+            in_tiles = int(getattr(owner_mod, "_exl3_in_tiles", 0))
+            out_tiles = int(getattr(owner_mod, "_exl3_out_tiles", 0))
+            if shard_id in ("w1", "w3"):
+                expect_prefix = (in_tiles, out_tiles)
+            else:
+                expect_prefix = (out_tiles, in_tiles)
+            if tuple(sharded.shape[:2]) != expect_prefix:
+                raise RuntimeError(
+                    f"EXL3 trellis tile mismatch {weight_name} shard={shard_id} "
+                    f"expert={expert_id}: got {tuple(sharded.shape)} "
+                    f"expected prefix {expect_prefix}+K_words"
+                )
+            if int(sharded.shape[-1]) % 16 != 0:
+                raise RuntimeError(
+                    f"EXL3 trellis K_words not multiple of 16: {tuple(sharded.shape)}"
+                )
+
+            use_arena = _exl3_trellis_arena_enabled()
+            if use_arena:
+                proj = _proj_from_shard_id(shard_id)
+                owner_mod._exl3_trellis_alloc_count_before = int(
+                    getattr(owner_mod, "_exl3_trellis_alloc_count_before", 0)
+                ) + 1
+                # Materialize deferred prescan plan on the exec device once.
+                pending = getattr(owner_mod, "_exl3_trellis_shapes_pending", None)
+                if (
+                    pending is not None
+                    and getattr(owner_mod, "_exl3_trellis_arena_plan", None) is None
+                ):
+                    prepare_trellis_arena_plan(owner_mod, pending)
+                    owner_mod._exl3_trellis_shapes_pending = None
+                    logger.info(
+                        "EXL3 trellis arenas allocated on %s: arenas=%s final_bytes=%s",
+                        owner_mod.w13_suh.device,
+                        owner_mod._exl3_trellis_arena_stats.get("allocations_after"),
+                        owner_mod._exl3_trellis_arena_stats.get("final_bytes"),
+                    )
+                # Preferred path: plan exists -> copy straight into FINAL slot.
+                if getattr(owner_mod, "_exl3_trellis_arena_plan", None) is not None:
+                    if _exl3_mem_waterfall_enabled():
+                        _exl3_mem_snapshot("AFTER_DEST_ALLOC", owner_mod)
+                        _exl3_mem_snapshot("AFTER_READ", owner_mod)
+                        _exl3_mem_snapshot("AFTER_LAYOUT_CONVERSION", owner_mod)
+                    _direct_fill_trellis_slot(owner_mod, proj, int(expert_id), sharded)
+                    if _exl3_mem_waterfall_enabled():
+                        _exl3_mem_snapshot("AFTER_COPY_TO_FINAL", owner_mod)
+                    del loaded, sharded, loaded_weight
+                    if _exl3_mem_waterfall_enabled():
+                        _exl3_mem_snapshot("AFTER_TEMP_DELETE", owner_mod)
+                        _exl3_mem_snapshot("AFTER_GC", owner_mod)
+                    return True if return_success else None
+
+                # Fallback: stage on host; pack in process_weights_after_loading.
+                if _exl3_mem_waterfall_enabled():
+                    _exl3_mem_snapshot("AFTER_DEST_ALLOC", owner_mod)
+                staged = sharded.detach()
+                if staged.device.type != "cpu":
+                    staged = staged.cpu()
+                if staged.dtype != torch.int16:
+                    staged = staged.to(dtype=torch.int16)
+                if not staged.is_contiguous():
+                    staged = staged.contiguous()
+                if _exl3_mem_waterfall_enabled():
+                    _exl3_mem_snapshot("AFTER_READ", owner_mod)
+                    _exl3_mem_snapshot("AFTER_LAYOUT_CONVERSION", owner_mod)
+                if not hasattr(owner_mod, "_exl3_trellis_staging"):
+                    owner_mod._exl3_trellis_staging = {
+                        "gate": {},
+                        "up": {},
+                        "down": {},
+                    }
+                owner_mod._exl3_trellis_staging[proj][int(expert_id)] = staged
+                if _exl3_mem_waterfall_enabled():
+                    _exl3_mem_snapshot("AFTER_COPY_TO_FINAL", owner_mod)
+                del loaded, sharded, loaded_weight
+                if _exl3_mem_waterfall_enabled():
+                    _exl3_mem_snapshot("AFTER_TEMP_DELETE", owner_mod)
+                return True if return_success else None
+
+            # Legacy: one independent Parameter allocation per expert.
+            dest_device = owner_mod.w13_suh.device
+            if _exl3_mem_waterfall_enabled():
+                _exl3_mem_snapshot("AFTER_DEST_ALLOC", owner_mod)
+            if (
+                sharded.dtype == torch.int16
+                and sharded.device == dest_device
+                and sharded.is_contiguous()
+            ):
+                payload = sharded
+            else:
+                payload = sharded.to(
+                    device=dest_device, dtype=torch.int16, non_blocking=False
+                ).contiguous()
+            if _exl3_mem_waterfall_enabled():
+                _exl3_mem_snapshot("AFTER_READ", owner_mod)
+                _exl3_mem_snapshot("AFTER_LAYOUT_CONVERSION", owner_mod)
+                _exl3_mem_snapshot("AFTER_COPY_TO_FINAL", owner_mod)
+            new_p = Parameter(payload, requires_grad=False)
+            new_p.weight_loader = self._load_exl3
+            new_p._exl3_owner = owner_mod
+            plist[expert_id] = new_p
+            owner_mod._exl3_trellis_alloc_count_before = int(
+                getattr(owner_mod, "_exl3_trellis_alloc_count_before", 0)
+            ) + 1
+            del loaded, sharded, payload, loaded_weight
+            if _exl3_mem_waterfall_enabled():
+                _exl3_mem_snapshot("AFTER_TEMP_DELETE", owner_mod)
+            return True if return_success else None
+
+        # suh / svh remain stacked (K-independent).
+        if owner_mod is None:
+            raise RuntimeError("EXL3 scale load missing owner module")
         if shard_id in ("w1", "w3"):
             shard_idx = 0 if shard_id == "w1" else 1
             sharded = shard_exl3_col(loaded, suffix, tp_rank, tp_size)
-            dest = param.data[expert_id, shard_idx]
+            dest = getattr(owner_mod, "w13_" + suffix).data[expert_id, shard_idx]
         elif shard_id == "w2":
             sharded = shard_exl3_row(loaded, suffix, tp_rank, tp_size)
-            dest = param.data[expert_id]
+            dest = getattr(owner_mod, "w2_" + suffix).data[expert_id]
         else:
             raise ValueError(f"unknown EXL3 shard_id={shard_id}")
 
+        if not sharded.is_contiguous():
+            sharded = sharded.contiguous()
         if tuple(dest.shape) != tuple(sharded.shape):
-            import os as _os
-            if _os.environ.get("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "0") != "1":
-                raise RuntimeError(
-                    f"EXL3 load shape mismatch {weight_name} shard={shard_id} "
-                    f"expert={expert_id}: dest {tuple(dest.shape)} != "
-                    f"loaded {tuple(sharded.shape)}. Set "
-                    f"VLLM_EXL3_ALLOW_SHAPE_MISMATCH=1 for diagnostic "
-                    f"loading with partial weight copy."
-                )
-            if dest.ndim != sharded.ndim:
-                # Rank mismatches cannot be coordinate-mapped; reject before
-                # zero-filling so a failed load leaves the destination intact.
-                raise RuntimeError(
-                    f"EXL3 diagnostic load requires matching rank for "
-                    f"{weight_name} shard={shard_id} expert={expert_id}: "
-                    f"dest {dest.ndim}D {tuple(dest.shape)} vs loaded "
-                    f"{sharded.ndim}D {tuple(sharded.shape)}."
-                )
-            logger.warning(
-                "EXL3 shape mismatch (DIAGNOSTIC) %s shard=%s expert=%s: "
-                "dest %s != loaded %s — zero-filling, coordinate-copying "
-                "per-dimension overlap. Model outputs WILL be incorrect.",
-                weight_name, shard_id, expert_id,
-                tuple(dest.shape), tuple(sharded.shape),
+            raise RuntimeError(
+                f"EXL3 load shape mismatch {weight_name} shard={shard_id} "
+                f"expert={expert_id}: dest {tuple(dest.shape)} != "
+                f"loaded {tuple(sharded.shape)}"
             )
-            dest.zero_()
-            slices = tuple(
-                slice(0, min(d, s)) for d, s in zip(dest.shape, sharded.shape)
-            )
-            dest[slices].copy_(sharded[slices].to(dest.dtype))
-            return True if return_success else None
         dest.copy_(sharded)
+        del loaded, sharded, loaded_weight
         return True if return_success else None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if not hasattr(layer, "w13_trellis"):
+        if not hasattr(layer, "gate_trellis"):
             return
+        # Pack staged trellis tensors into contiguous per-shape arenas before
+        # building LinearEXL3 handles. Views preserve exact heterogeneous K.
+        # Direct-fill plans have empty staging but still need stats finalized.
+        staging = getattr(layer, "_exl3_trellis_staging", None) or {}
+        staged_n = sum(len(m) for m in staging.values() if isinstance(m, dict))
+        has_plan = getattr(layer, "_exl3_trellis_arena_plan", None) is not None
+        if _exl3_trellis_arena_enabled() and (staged_n > 0 or has_plan):
+            if _exl3_mem_waterfall_enabled():
+                _exl3_mem_snapshot("BEFORE_ARENA_PACK", layer)
+            alloc_before = int(getattr(layer, "_exl3_trellis_alloc_count_before", 0))
+            alloc_before = max(alloc_before, staged_n)
+            stats = _pack_trellis_arenas(layer)
+            stats["allocations_before"] = alloc_before
+            layer._exl3_trellis_arena_stats = stats
+            if _exl3_mem_waterfall_enabled():
+                _exl3_mem_snapshot("AFTER_ARENA_PACK", layer)
+                _exl3_mem_snapshot("AFTER_GC", layer)
+            if not self._logged:
+                logger.info(
+                    "EXL3 trellis arenas: before_allocs=%s after_arenas=%s "
+                    "final_bytes=%s temp_peak_bytes=%s",
+                    stats.get("allocations_before"),
+                    stats.get("allocations_after"),
+                    stats.get("final_bytes"),
+                    stats.get("temp_peak_bytes"),
+                )
+
         # Bind owner for any late loads; stitch LinearEXL3 handles.
         for name in (
             "w13_trellis",
@@ -2028,36 +2667,59 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "w2_mcg",
             "w2_mul1",
         ):
-            getattr(layer, name)._exl3_owner = layer
+            if hasattr(layer, name):
+                getattr(layer, name)._exl3_owner = layer
+        for plist in (layer.gate_trellis, layer.up_trellis, layer.down_trellis):
+            for param in plist:
+                param._exl3_owner = layer
+                param.weight_loader = self._load_exl3
         _check_moe_codebook_markers(layer.w13_mcg, layer.w13_mul1, "w13")
         _check_moe_codebook_markers(layer.w2_mcg, layer.w2_mul1, "w2")
 
-        n_exp = int(layer.w13_trellis.shape[0])
+        n_exp = int(len(layer.gate_trellis))
         inners: list[dict[str, Any]] = []
+        k_values: list[int] = []
         for e in range(n_exp):
+            gt = layer.gate_trellis[e]
+            ut = layer.up_trellis[e]
+            dt = layer.down_trellis[e]
+            if gt.numel() == 0 or ut.numel() == 0 or dt.numel() == 0:
+                raise RuntimeError(
+                    f"EXL3 mixed-K load incomplete for local expert {e}: "
+                    f"gate={tuple(gt.shape)} up={tuple(ut.shape)} down={tuple(dt.shape)}"
+                )
             gate = make_linear_exl3(
-                layer.w13_trellis[e, 0],
+                gt,
                 layer.w13_suh[e, 0],
                 layer.w13_svh[e, 0],
                 _moe_marker_or_none(layer.w13_mcg[e, 0]),
                 _moe_marker_or_none(layer.w13_mul1[e, 0]),
             )
             up = make_linear_exl3(
-                layer.w13_trellis[e, 1],
+                ut,
                 layer.w13_suh[e, 1],
                 layer.w13_svh[e, 1],
                 _moe_marker_or_none(layer.w13_mcg[e, 1]),
                 _moe_marker_or_none(layer.w13_mul1[e, 1]),
             )
             down = make_linear_exl3(
-                layer.w2_trellis[e],
+                dt,
                 layer.w2_suh[e],
                 layer.w2_svh[e],
                 _moe_marker_or_none(layer.w2_mcg[e]),
                 _moe_marker_or_none(layer.w2_mul1[e]),
             )
             inners.append({"gate": gate, "up": up, "down": down})
+            k_values.extend(
+                [
+                    int(gt.shape[-1]) // 16,
+                    int(ut.shape[-1]) // 16,
+                    int(dt.shape[-1]) // 16,
+                ]
+            )
         layer._exl3_inners = inners
+        mixed_k = len(set(k_values)) > 1
+        layer._exl3_mixed_k = mixed_k
         # Codebook flags (mcg, mul1) per projection for the fused kernel launch;
         # every expert in a layer must agree.
         if inners:
@@ -2079,10 +2741,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer._exl3_codebook_flags = flags
         fused_ok = False
         fused_err = None
-        # Native dispatch has its own environment control and must still build
-        # pointer tables when the legacy EXL3_FUSED_MOE switch is disabled.
+        # Fused/native MoE launches take a single K for gate/up/down across the
+        # whole layer. Heterogeneous packed K must use the LinearEXL3 loop.
         backend = get_moe_kernel_backend()
-        if fused_moe_enabled() or backend == "native":
+        if mixed_k:
+            fused_err = f"mixed_packed_K={sorted(set(k_values))}"
+            layer._exl3_ptrs = None
+            layer._exl3_fused_temps = None
+            layer._exl3_fused_concurrency = 0
+        elif fused_moe_enabled() or backend == "native":
             try:
                 has_native = backend == "native" and native_moe_kernel_available()
                 has_exllamav3 = _exllamav3_moe_available()
@@ -2118,15 +2785,23 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 logger.info(
                     "EXL3 MCG trellis engaged for routed experts: bits=%s "
                     "experts_local=%s hidden=%s intermediate_local=%s "
-                    "fused_moe=python_loop (%s) "
+                    "fused_moe=python_loop (%s) mixed_k=%s "
                     "(no BF16 expert reconstruct at load)",
                     self.bits,
                     n_exp,
                     layer._exl3_hidden_size,
                     layer._exl3_intermediate_local,
                     fused_err or "EXL3_FUSED_MOE=0",
+                    mixed_k,
                 )
             self._logged = True
+        # Release transient load leftovers between MoE layers on UMA hosts.
+        gc.collect()
+        if torch is not None and torch.cuda.is_available():
+            try:
+                torch.cuda.empty_cache()
+            except Exception:
+                pass
 
     def apply(
         self,

--- a/src/vllm_exl3/k78_compat.py
+++ b/src/vllm_exl3/k78_compat.py
@@ -7,9 +7,9 @@ qualified for. Historically Exl3Config rejected K7/K8 before dispatch could use
 ExLlamaV3's normal execution path.
 
 This narrow installer widens *configuration acceptance* to K2-K8 without
-claiming custom-native support for K5-K8. It does not add tensor-level mixed-K
-inside one RoutedExperts layer; current routed-MoE allocation still expects one
-K per transformer layer.
+claiming custom-native support for K5-K8. Tensor-level mixed-K inside one
+RoutedExperts layer is handled separately by ragged per-expert trellis
+allocation in ``Exl3MoEMethod`` (python_loop when K disagrees).
 """
 from __future__ import annotations
 

--- a/src/vllm_exl3/mixed_k_guard.py
+++ b/src/vllm_exl3/mixed_k_guard.py
@@ -1,0 +1,55 @@
+"""Safety guards for mixed-K trellis prescan.
+
+The low-memory arena prescan maps local expert ids onto checkpoint expert ids.
+That mapping is only valid when vLLM uses linear expert placement. Other
+placement/EPLB strategies must fall back to the normal loader, which already
+uses vLLM's authoritative expert map.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _placement_strategy(layer: Any) -> str | None:
+    value = getattr(layer, "expert_placement_strategy", None)
+    if value is None:
+        manager = getattr(layer, "expert_map_manager", None)
+        value = getattr(manager, "placement_strategy", None) if manager is not None else None
+    return str(value).lower() if value is not None else None
+
+
+def _eplb_active(layer: Any) -> bool:
+    for owner in (layer, getattr(layer, "expert_map_manager", None)):
+        if owner is None:
+            continue
+        for name in ("enable_eplb", "eplb_enabled"):
+            if bool(getattr(owner, name, False)):
+                return True
+    return False
+
+
+def install_mixed_k_prescan_guard(exl3_module: Any) -> None:
+    current = getattr(exl3_module, "_try_prescan_trellis_shapes", None)
+    if not callable(current):
+        return
+    if bool(getattr(current, "_vllm_exl3_mixed_k_prescan_guard", False)):
+        return
+
+    def guarded(layer: Any, num_experts: int):
+        placement = _placement_strategy(layer)
+        if _eplb_active(layer) or placement not in (None, "linear"):
+            logger = getattr(exl3_module, "logger", None)
+            if logger is not None:
+                getattr(logger, "info_once", logger.info)(
+                    "EXL3 mixed-K arena prescan disabled for expert placement=%s "
+                    "eplb=%s; falling back to authoritative loader mapping",
+                    placement or "unknown",
+                    _eplb_active(layer),
+                )
+            return None
+        return current(layer, num_experts)
+
+    guarded._vllm_exl3_mixed_k_prescan_guard = True
+    guarded._vllm_exl3_original = current
+    exl3_module._try_prescan_trellis_shapes = guarded
+    exl3_module._vllm_exl3_mixed_k_prescan_guard_installed = True

--- a/tests/test_arena_direct_fill.py
+++ b/tests/test_arena_direct_fill.py
@@ -1,0 +1,148 @@
+"""Direct-to-arena fill vs legacy on synthetic mixed-K tensors."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import vllm_exl3.exl3 as exl3
+
+
+def _new_moe_method(moe, cfg, bits: int = 4):
+    """Construct Exl3MoEMethod without requiring a real vLLM FusedMoEMethodBase."""
+    method = object.__new__(exl3.Exl3MoEMethod)
+    method.moe = moe
+    method.quant_config = cfg
+    method.bits = int(bits)
+    method._logged = False
+    return method
+
+
+class _MoeCfg:
+    hidden_dim = 64
+    num_experts = 4
+    num_local_experts = 4
+    experts_per_token = 2
+    activation = "silu"
+    rocm_aiter_fmoe_enabled = False
+    swiglu_limit = None
+
+
+class _Layer(torch.nn.Module):
+    def __init__(self, n: int) -> None:
+        super().__init__()
+        self.moe_config = _MoeCfg()
+        self.layer_name = "layers.0.ffn.experts"
+        self.global_num_experts = n
+        self.local_num_experts = n
+        self.starting_expert_offset = 0
+
+    def _map_global_expert_id_to_local_expert_id(self, expert_id: int) -> int:
+        return int(expert_id) if 0 <= int(expert_id) < self.local_num_experts else -1
+
+
+def _stub_linear(trellis, suh, svh, mcg=None, mul1=None, **_kwargs):
+    return SimpleNamespace(
+        trellis=trellis, suh=suh, svh=svh, mcg=True, mul1=False,
+        forward=lambda *a, **k: None,
+    )
+
+
+def _make(n: int = 4):
+    method = _new_moe_method(_MoeCfg(), exl3.Exl3Config(bits=4, codebook="mcg", scope="test"), bits=4)
+    layer = _Layer(n)
+    method.create_weights(
+        layer,
+        num_experts=n,
+        hidden_size=64,
+        intermediate_size_per_partition=64,
+        params_dtype=torch.bfloat16,
+    )
+    layer.moe_tp_size = 1
+    layer.tp_rank = 0
+    return method, layer
+
+
+def _trellis(in_t, out_t, k):
+    return torch.arange(in_t * out_t * k * 16, dtype=torch.int16).reshape(
+        in_t, out_t, k * 16
+    )
+
+
+def _load_all(method, layer, ks_gate, ks_up, ks_down, *, arena: bool):
+    import os
+
+    os.environ["VLLM_EXL3_TRELLIS_ARENA"] = "1" if arena else "0"
+    os.environ["VLLM_EXL3_ARENA_PRESCAN"] = "0"
+    for eid, (kg, ku, kd) in enumerate(zip(ks_gate, ks_up, ks_down)):
+        payloads = {
+            ("w1", "trellis"): _trellis(4, 4, kg),
+            ("w3", "trellis"): _trellis(4, 4, ku),
+            ("w2", "trellis"): _trellis(4, 4, kd),
+            ("w1", "suh"): torch.ones(64, dtype=torch.float16),
+            ("w3", "suh"): torch.ones(64, dtype=torch.float16),
+            ("w2", "suh"): torch.ones(64, dtype=torch.float16),
+            ("w1", "svh"): torch.ones(64, dtype=torch.float16),
+            ("w3", "svh"): torch.ones(64, dtype=torch.float16),
+            ("w2", "svh"): torch.ones(64, dtype=torch.float16),
+            ("w1", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+            ("w3", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+            ("w2", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+        }
+        for (proj, kind), tensor in payloads.items():
+            if kind == "trellis":
+                param = layer.w13_trellis if proj in ("w1", "w3") else layer.w2_trellis
+            else:
+                param = (
+                    getattr(layer, f"w13_{kind}")
+                    if proj in ("w1", "w3")
+                    else getattr(layer, f"w2_{kind}")
+                )
+            assert method._load_exl3(
+                param,
+                tensor,
+                f"experts.{eid}.{proj}.{kind}",
+                shard_id=proj,
+                expert_id=eid,
+                return_success=True,
+            )
+
+
+def test_direct_vs_legacy_parity_and_storage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(exl3, "make_linear_exl3", _stub_linear)
+    ks = [3, 8, 4, 5]
+    ups = [4, 8, 4, 5]  # expert 0: w1=K3, w3=K4
+
+    method_l, layer_l = _make(4)
+    _load_all(method_l, layer_l, ks, ups, ks, arena=False)
+    method_l.process_weights_after_loading(layer_l)
+
+    method_d, layer_d = _make(4)
+    monkeypatch.setenv("VLLM_EXL3_TRELLIS_ARENA", "1")
+    monkeypatch.setenv("VLLM_EXL3_ARENA_PRESCAN", "0")
+    shapes = {
+        "gate": {i: (4, 4, k * 16) for i, k in enumerate(ks)},
+        "up": {i: (4, 4, k * 16) for i, k in enumerate(ups)},
+        "down": {i: (4, 4, k * 16) for i, k in enumerate(ks)},
+    }
+    exl3.prepare_trellis_arena_plan(layer_d, shapes)
+    _load_all(method_d, layer_d, ks, ups, ks, arena=True)
+    method_d.process_weights_after_loading(layer_d)
+
+    assert layer_d._exl3_mixed_k is True
+    assert exl3._count_trellis_storages(layer_d) < exl3._count_trellis_storages(layer_l)
+    assert exl3._trellis_nbytes(layer_d) == exl3._trellis_nbytes(layer_l)
+    assert layer_d._exl3_trellis_arena_stats.get("mode") == "direct_plan"
+    assert (
+        int(layer_d._exl3_trellis_arena_stats["temp_peak_bytes"])
+        < int(layer_d._exl3_trellis_arena_stats["final_bytes"]) // 4
+    )
+    for eid in range(4):
+        assert torch.equal(layer_d.gate_trellis[eid].cpu(), layer_l.gate_trellis[eid].cpu())
+        assert torch.equal(layer_d.up_trellis[eid].cpu(), layer_l.up_trellis[eid].cpu())
+        assert torch.equal(layer_d.down_trellis[eid].cpu(), layer_l.down_trellis[eid].cpu())
+    assert layer_d.gate_trellis[0].shape[-1] // 16 == 3
+    assert layer_d.up_trellis[0].shape[-1] // 16 == 4

--- a/tests/test_loader_parity.py
+++ b/tests/test_loader_parity.py
@@ -9,6 +9,16 @@ torch = pytest.importorskip("torch")
 import vllm_exl3.exl3 as exl3
 
 
+def _new_moe_method(moe, cfg, bits: int = 4):
+    """Construct Exl3MoEMethod without requiring a real vLLM FusedMoEMethodBase."""
+    method = object.__new__(exl3.Exl3MoEMethod)
+    method.moe = moe
+    method.quant_config = cfg
+    method.bits = int(bits)
+    method._logged = False
+    return method
+
+
 class _ReadOnlyExpertMapLayer:
     def __init__(self, expert_map: torch.Tensor) -> None:
         self._raw_expert_map = expert_map
@@ -18,32 +28,57 @@ class _ReadOnlyExpertMapLayer:
         return self._raw_expert_map
 
 
-class _MoEOwner:
+class _MoEOwner(torch.nn.Module):
     tp_rank = 0
     tp_size = 1
+    moe_tp_size = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer_name = "layers.0.ffn.experts"
+        self.global_num_experts = 1
+        self.local_num_experts = 1
+        self.starting_expert_offset = 0
+        self.moe_config = SimpleNamespace(
+            hidden_dim=16,
+            num_experts=1,
+            num_local_experts=1,
+            experts_per_token=1,
+            activation="silu",
+            rocm_aiter_fmoe_enabled=False,
+            swiglu_limit=None,
+        )
 
     def _map_global_expert_id_to_local_expert_id(self, expert_id: int) -> int:
-        return expert_id
+        return expert_id if 0 <= int(expert_id) < 1 else -1
 
 
-def test_moe_loader_prefers_layer_tp_geometry() -> None:
+def test_moe_loader_prefers_layer_tp_geometry(monkeypatch: pytest.MonkeyPatch) -> None:
     """A MoE layer with TP=1 must not inherit process TP=8 slicing."""
+    monkeypatch.setenv("VLLM_EXL3_TRELLIS_ARENA", "0")
+    monkeypatch.setenv("VLLM_EXL3_ARENA_PRESCAN", "0")
     owner = _MoEOwner()
-    param = torch.nn.Parameter(
-        torch.empty(1, 2, 1, 1, 32, dtype=torch.int16), requires_grad=False
+    method = _new_moe_method(owner.moe_config, exl3.Exl3Config(bits=2, codebook="mcg", scope="test"), bits=2)
+    method.create_weights(
+        owner,
+        num_experts=1,
+        hidden_size=16,
+        intermediate_size_per_partition=16,
+        params_dtype=torch.bfloat16,
     )
-    param._exl3_owner = owner
-    loaded = torch.arange(32, dtype=torch.int16).reshape(1, 1, 32)
-    method = object.__new__(exl3.Exl3MoEMethod)
-    method._load_exl3(
-        param,
+    owner.moe_tp_size = 1
+    owner.tp_rank = 0
+    loaded = torch.arange(1 * 1 * 32, dtype=torch.int16).reshape(1, 1, 32)
+    ok = method._load_exl3(
+        owner.w13_trellis,
         loaded,
         "experts.w13_trellis",
         shard_id="w1",
         expert_id=0,
+        return_success=True,
     )
-
-    torch.testing.assert_close(param[0, 0], loaded)
+    assert ok is True
+    torch.testing.assert_close(owner.gate_trellis[0], loaded)
 
 
 def test_pin_expert_map_uses_private_cache_for_read_only_property() -> None:
@@ -121,173 +156,52 @@ def test_qkv_loader_replicated_kv_heads_uses_shard_specific_tp() -> None:
     torch.testing.assert_close(svh[512:640], loaded_svh)
 
 
-def _mismatch_param(dest_shape: tuple[int, ...]) -> torch.nn.Parameter:
-    """w1 slot-0 parameter whose destination slice has ``dest_shape``."""
-    param = torch.nn.Parameter(
-        torch.full((1, 2, *dest_shape), 7, dtype=torch.float32),
-        requires_grad=False,
+def test_suh_shape_mismatch_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scale tensors still hard-fail on shape mismatch (exact dest geometry)."""
+    monkeypatch.setenv("VLLM_EXL3_TRELLIS_ARENA", "0")
+    owner = _MoEOwner()
+    method = _new_moe_method(owner.moe_config, exl3.Exl3Config(bits=2, codebook="mcg", scope="test"), bits=2)
+    method.create_weights(
+        owner,
+        num_experts=1,
+        hidden_size=16,
+        intermediate_size_per_partition=16,
+        params_dtype=torch.bfloat16,
     )
-    param._exl3_owner = _MoEOwner()
-    return param
-
-
-def test_shape_mismatch_raises_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Without the opt-in env var a mismatched load must hard-fail untouched."""
-    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "0")
-    param = _mismatch_param((3, 4))
-    method = object.__new__(exl3.Exl3MoEMethod)
-
+    owner.moe_tp_size = 1
+    owner.tp_rank = 0
     with pytest.raises(RuntimeError, match="shape mismatch"):
         method._load_exl3(
-            param,
-            torch.arange(8, dtype=torch.float32).reshape(2, 4),
-            "experts.w13_trellis",
+            owner.w13_suh,
+            torch.arange(8, dtype=torch.float16),
+            "experts.w13_suh",
             shard_id="w1",
             expert_id=0,
             return_success=True,
         )
 
-    assert (param.data[0, 0] == 7).all()
 
-
-def test_diagnostic_mode_source_smaller_zero_fills_and_coordinate_copies(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Opt-in padding: overlap is coordinate-copied, the tail zero-filled."""
-    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
-    param = _mismatch_param((3, 4))
-    src = torch.arange(8, dtype=torch.float32).reshape(2, 4) + 1
-    method = object.__new__(exl3.Exl3MoEMethod)
-
-    result = method._load_exl3(
-        param, src, "experts.w13_trellis",
-        shard_id="w1", expert_id=0, return_success=True,
+def test_trellis_exact_shape_replaces_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VLLM_EXL3_TRELLIS_ARENA", "0")
+    owner = _MoEOwner()
+    method = _new_moe_method(owner.moe_config, exl3.Exl3Config(bits=2, codebook="mcg", scope="test"), bits=2)
+    method.create_weights(
+        owner,
+        num_experts=1,
+        hidden_size=16,
+        intermediate_size_per_partition=16,
+        params_dtype=torch.bfloat16,
     )
-
-    assert result is True
-    torch.testing.assert_close(param.data[0, 0, :2], src)
-    assert (param.data[0, 0, 2:] == 0).all()
-
-
-def test_diagnostic_mode_source_larger_coordinate_trims(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Opt-in trimming: only the leading per-dimension overlap is kept."""
-    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
-    param = _mismatch_param((2, 4))
-    src = torch.arange(15, dtype=torch.float32).reshape(3, 5) + 1
-    method = object.__new__(exl3.Exl3MoEMethod)
-
-    result = method._load_exl3(
-        param, src, "experts.w13_trellis",
-        shard_id="w1", expert_id=0, return_success=True,
-    )
-
-    assert result is True
-    torch.testing.assert_close(param.data[0, 0], src[:2, :4])
-
-
-def test_diagnostic_mode_equal_numel_keeps_coordinates(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Equal-numel/different-shape: rows must not be packed across rows.
-
-    A flattened prefix copy would fill ``dest[2]`` from ``src[1]``'s tail;
-    the coordinate copy leaves the non-overlapping row zero. The source is
-    deliberately non-contiguous with 12 elements, like the destination.
-    """
-    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
-    param = _mismatch_param((3, 4))
-    src = (torch.arange(24, dtype=torch.float32).reshape(4, 6) + 1)[::2]
-    assert not src.is_contiguous()
-    assert tuple(src.shape) == (2, 6)
-    method = object.__new__(exl3.Exl3MoEMethod)
-
-    method._load_exl3(
-        param, src, "experts.w13_trellis", shard_id="w1", expert_id=0,
-    )
-
-    torch.testing.assert_close(param.data[0, 0, :2], src[:, :4])
-    assert (param.data[0, 0, 2:] == 0).all()
-
-
-def test_diagnostic_mode_dtype_converted_on_copy(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Opt-in copy narrows the source dtype to the destination dtype."""
-    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
-    param = torch.nn.Parameter(
-        torch.full((1, 2, 3, 4), 7, dtype=torch.float16), requires_grad=False
-    )
-    param._exl3_owner = _MoEOwner()
-    src = torch.arange(8, dtype=torch.float32).reshape(2, 4) + 1
-    method = object.__new__(exl3.Exl3MoEMethod)
-
-    method._load_exl3(
-        param, src, "experts.w13_trellis", shard_id="w1", expert_id=0,
-    )
-
-    torch.testing.assert_close(
-        param.data[0, 0, :2], src.to(torch.float16), rtol=0, atol=0
-    )
-    assert (param.data[0, 0, 2:] == 0).all()
-
-
-def test_diagnostic_mode_ndim_mismatch_raises(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Rank mismatches stay a hard error even in diagnostic mode."""
-    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
-    param = _mismatch_param((3, 4))
-    method = object.__new__(exl3.Exl3MoEMethod)
-
-    with pytest.raises(RuntimeError, match="matching rank"):
-        method._load_exl3(
-            param,
-            torch.arange(12, dtype=torch.float32).reshape(3, 4, 1),
-            "experts.w13_trellis",
-            shard_id="w1",
-            expert_id=0,
-            return_success=True,
-        )
-
-    assert (param.data[0, 0] == 7).all()
-
-
-def test_return_success_only_in_diagnostic_mode(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Mismatched loads report success only with the explicit opt-in."""
-    param = _mismatch_param((3, 4))
-    mismatched = torch.arange(8, dtype=torch.float32).reshape(2, 4)
-    method = object.__new__(exl3.Exl3MoEMethod)
-
-    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "1")
+    owner.moe_tp_size = 1
+    owner.tp_rank = 0
+    loaded = torch.arange(1 * 1 * 48, dtype=torch.int16).reshape(1, 1, 48)  # K=3
     assert method._load_exl3(
-        param, mismatched, "experts.w13_trellis",
-        shard_id="w1", expert_id=0, return_success=True,
+        owner.w13_trellis,
+        loaded,
+        "experts.0.w1.trellis",
+        shard_id="w1",
+        expert_id=0,
+        return_success=True,
     )
-    monkeypatch.setenv("VLLM_EXL3_ALLOW_SHAPE_MISMATCH", "0")
-    with pytest.raises(RuntimeError, match="shape mismatch"):
-        method._load_exl3(
-            param, mismatched, "experts.w13_trellis",
-            shard_id="w1", expert_id=0, return_success=True,
-        )
-
-    # Matching shapes succeed regardless of the diagnostic opt-in.
-    matched_param = torch.nn.Parameter(
-        torch.zeros(1, 2, 2, 4, dtype=torch.float32), requires_grad=False
-    )
-    matched_param._exl3_owner = _MoEOwner()
-    matched = torch.arange(8, dtype=torch.float32).reshape(2, 4)
-    assert method._load_exl3(
-        matched_param, matched, "experts.w13_trellis",
-        shard_id="w1", expert_id=0, return_success=True,
-    )
-    assert (
-        method._load_exl3(
-            matched_param, matched, "experts.w13_trellis",
-            shard_id="w1", expert_id=0,
-        )
-        is None
-    )
+    assert tuple(owner.gate_trellis[0].shape) == (1, 1, 48)
+    torch.testing.assert_close(owner.gate_trellis[0], loaded)

--- a/tests/test_mixed_k_exl3.py
+++ b/tests/test_mixed_k_exl3.py
@@ -1,0 +1,203 @@
+"""Synthetic CPU tests for per-expert heterogeneous packed-K EXL3 MoE loads."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import vllm_exl3
+import vllm_exl3.exl3 as exl3
+
+
+def _new_moe_method(moe, cfg, bits: int = 4):
+    """Construct Exl3MoEMethod without requiring a real vLLM FusedMoEMethodBase."""
+    method = object.__new__(exl3.Exl3MoEMethod)
+    method.moe = moe
+    method.quant_config = cfg
+    method.bits = int(bits)
+    method._logged = False
+    return method
+
+
+class _MoeCfg:
+    hidden_dim = 64
+    num_experts = 4
+    num_local_experts = 4
+    experts_per_token = 2
+    activation = "silu"
+    rocm_aiter_fmoe_enabled = False
+    swiglu_limit = None
+
+
+class _Layer(torch.nn.Module):
+    def __init__(self, n_experts: int) -> None:
+        super().__init__()
+        self.moe_config = _MoeCfg()
+        self.layer_name = "layers.0.ffn.experts"
+        self.global_num_experts = n_experts
+        self.local_num_experts = n_experts
+        self.starting_expert_offset = 0
+
+    def _map_global_expert_id_to_local_expert_id(self, expert_id: int) -> int:
+        return int(expert_id) if 0 <= int(expert_id) < self.local_num_experts else -1
+
+
+def _stub_linear(trellis, suh, svh, mcg=None, mul1=None, **_kwargs):
+    return SimpleNamespace(
+        trellis=trellis,
+        suh=suh,
+        svh=svh,
+        mcg=True if mcg is None else bool(int(mcg.reshape(-1)[0].item()) != 0)
+        if mcg.numel()
+        else True,
+        mul1=False if mul1 is None else bool(int(mul1.reshape(-1)[0].item()) != 0)
+        if mul1.numel()
+        else False,
+        forward=lambda *a, **k: None,
+    )
+
+
+def _make_method_layer(n_experts: int = 4, bits: int = 4, hidden: int = 64, inter: int = 64):
+    cfg = exl3.Exl3Config(bits=bits, codebook="mcg", scope="test")
+    method = _new_moe_method(_MoeCfg(), cfg, bits=bits)
+    layer = _Layer(n_experts)
+    method.create_weights(
+        layer,
+        num_experts=n_experts,
+        hidden_size=hidden,
+        intermediate_size_per_partition=inter,
+        params_dtype=torch.bfloat16,
+    )
+    layer.moe_tp_size = 1
+    layer.tp_rank = 0
+    return method, layer
+
+
+def _trellis(in_tiles: int, out_tiles: int, k: int) -> torch.Tensor:
+    return torch.arange(in_tiles * out_tiles * k * 16, dtype=torch.int16).reshape(
+        in_tiles, out_tiles, k * 16
+    )
+
+
+def _load_expert(method, layer, eid: int, k_gate: int, k_up: int, k_down: int) -> None:
+    in_tiles = layer._exl3_in_tiles
+    out_tiles = layer._exl3_out_tiles
+    hidden = layer._exl3_hidden_size
+    inter = layer._exl3_intermediate_local
+    payloads = {
+        ("w1", "trellis"): _trellis(in_tiles, out_tiles, k_gate),
+        ("w3", "trellis"): _trellis(in_tiles, out_tiles, k_up),
+        ("w2", "trellis"): _trellis(out_tiles, in_tiles, k_down),
+        ("w1", "suh"): torch.ones(hidden, dtype=torch.float16),
+        ("w3", "suh"): torch.ones(hidden, dtype=torch.float16),
+        ("w2", "suh"): torch.ones(inter, dtype=torch.float16),
+        ("w1", "svh"): torch.ones(inter, dtype=torch.float16),
+        ("w3", "svh"): torch.ones(inter, dtype=torch.float16),
+        ("w2", "svh"): torch.ones(hidden, dtype=torch.float16),
+        ("w1", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+        ("w3", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+        ("w2", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+    }
+    for (proj, kind), tensor in payloads.items():
+        if kind == "trellis":
+            param = layer.w13_trellis if proj in ("w1", "w3") else layer.w2_trellis
+        else:
+            param = (
+                getattr(layer, f"w13_{kind}")
+                if proj in ("w1", "w3")
+                else getattr(layer, f"w2_{kind}")
+            )
+        ok = method._load_exl3(
+            param,
+            tensor,
+            f"layers.0.ffn.experts.{eid}.{proj}.{kind}",
+            shard_id=proj,
+            expert_id=eid,
+            return_success=True,
+        )
+        assert ok is True, (eid, proj, kind)
+
+
+@pytest.fixture(autouse=True)
+def _legacy_arena_default(monkeypatch: pytest.MonkeyPatch):
+    # Default unit path: legacy per-expert allocs unless a test opts into arenas.
+    monkeypatch.setenv("VLLM_EXL3_TRELLIS_ARENA", "0")
+    monkeypatch.setenv("VLLM_EXL3_ARENA_PRESCAN", "0")
+    monkeypatch.setenv("EXL3_FUSED_MOE", "0")
+
+
+def test_create_weights_uses_ragged_parameter_lists() -> None:
+    method, layer = _make_method_layer(n_experts=3)
+    assert len(layer.gate_trellis) == 3
+    assert len(layer.up_trellis) == 3
+    assert len(layer.down_trellis) == 3
+    assert tuple(layer.w13_trellis.shape) == (0,)
+    assert getattr(layer, "_exl3_mixed_k", None) is False
+
+
+def test_exact_shape_load_for_k_classes_3_through_8(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(exl3, "make_linear_exl3", _stub_linear)
+    method, layer = _make_method_layer(n_experts=6, bits=4)
+    # One expert per K in 3..8; also force w1!=w3 on expert 0.
+    k_classes = list(range(3, 9))
+    for eid, k in enumerate(k_classes):
+        k_gate = k
+        k_up = 4 if eid == 0 else k  # expert 0: w1=K3, w3=K4
+        k_down = k
+        _load_expert(method, layer, eid, k_gate, k_up, k_down)
+
+    method.process_weights_after_loading(layer)
+    assert layer._exl3_mixed_k is True
+    assert getattr(layer, "_exl3_ptrs", None) in (None, {})
+    assert len(layer._exl3_inners) == 6
+    assert tuple(layer.gate_trellis[0].shape)[-1] // 16 == 3
+    assert tuple(layer.up_trellis[0].shape)[-1] // 16 == 4
+    for eid, k in enumerate(k_classes):
+        assert tuple(layer.gate_trellis[eid].shape)[-1] // 16 == (3 if eid == 0 else k)
+        assert tuple(layer.down_trellis[eid].shape)[-1] // 16 == k
+
+
+def test_intra_expert_w1_ne_w3_forces_python_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(exl3, "make_linear_exl3", _stub_linear)
+    method, layer = _make_method_layer(n_experts=2, bits=4)
+    _load_expert(method, layer, 0, k_gate=3, k_up=5, k_down=4)
+    _load_expert(method, layer, 1, k_gate=3, k_up=5, k_down=4)
+    method.process_weights_after_loading(layer)
+    assert layer._exl3_mixed_k is True
+    assert layer._exl3_ptrs is None
+
+
+def test_uniform_k_keeps_mixed_flag_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(exl3, "make_linear_exl3", _stub_linear)
+    method, layer = _make_method_layer(n_experts=2, bits=4)
+    _load_expert(method, layer, 0, 4, 4, 4)
+    _load_expert(method, layer, 1, 4, 4, 4)
+    method.process_weights_after_loading(layer)
+    assert layer._exl3_mixed_k is False
+    # No fused kernel in this CPU env, but mixed_k must not be the reason.
+    assert getattr(layer, "_exl3_ptrs", None) in (None, {})
+
+
+def test_trellis_tile_mismatch_raises() -> None:
+    method, layer = _make_method_layer(n_experts=1)
+    bad = torch.zeros(2, 2, 64, dtype=torch.int16)  # wrong tile prefix
+    with pytest.raises(RuntimeError, match="tile mismatch"):
+        method._load_exl3(
+            layer.w13_trellis,
+            bad,
+            "layers.0.ffn.experts.0.w1.trellis",
+            shard_id="w1",
+            expert_id=0,
+            return_success=True,
+        )
+
+
+def test_runtime_diagnostics_advertise_tensor_level_mixed_k() -> None:
+    diag = vllm_exl3.runtime_diagnostics()
+    mixed = diag["mixed_k"]
+    assert mixed["tensor_level_mixed_k_within_layer"] is True
+    assert mixed["heterogeneous_dispatch"] == "python_loop"
+    assert "python_loop" in mixed["note"]

--- a/tests/test_mixed_k_runtime_contract.py
+++ b/tests/test_mixed_k_runtime_contract.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import vllm_exl3
+
+
+def test_mixed_k_runtime_contract_is_explicit() -> None:
+    mixed = vllm_exl3.runtime_diagnostics()["mixed_k"]
+    assert mixed["tensor_level_mixed_k_within_layer"] is True
+    assert mixed["heterogeneous_dispatch"] == "python_loop"
+    assert mixed["uniform_k_dispatch"] == "fused_when_available"
+    assert mixed["cudagraph_qualified"] is False
+    assert mixed["recommended_first_boot"] == "eager"
+    assert mixed["arena_prescan_placement_contract"] == (
+        "linear_contiguous_global_expert_ids"
+    )
+    assert mixed["legacy_shape_overlap_diagnostic"] is False

--- a/tests/test_mixed_k_runtime_contract.py
+++ b/tests/test_mixed_k_runtime_contract.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import vllm_exl3
+import vllm_exl3.exl3 as exl3
+from vllm_exl3.mixed_k_guard import install_mixed_k_prescan_guard
 
 
 def test_mixed_k_runtime_contract_is_explicit() -> None:
@@ -13,4 +17,36 @@ def test_mixed_k_runtime_contract_is_explicit() -> None:
     assert mixed["arena_prescan_placement_contract"] == (
         "linear_contiguous_global_expert_ids"
     )
+    assert mixed["arena_prescan_guard_installed"] is True
     assert mixed["legacy_shape_overlap_diagnostic"] is False
+
+
+def test_prescan_guard_skips_non_linear_placement(monkeypatch) -> None:
+    calls: list[int] = []
+
+    def fake_prescan(layer, num_experts):
+        calls.append(num_experts)
+        return {"gate": {}, "up": {}, "down": {}}
+
+    monkeypatch.setattr(exl3, "_try_prescan_trellis_shapes", fake_prescan)
+    monkeypatch.delattr(exl3, "_vllm_exl3_mixed_k_prescan_guard_installed", raising=False)
+    install_mixed_k_prescan_guard(exl3)
+
+    layer = SimpleNamespace(expert_placement_strategy="round_robin")
+    assert exl3._try_prescan_trellis_shapes(layer, 96) is None
+    assert calls == []
+
+
+def test_prescan_guard_allows_linear_placement(monkeypatch) -> None:
+    expected = {"gate": {0: (1, 1, 48)}, "up": {}, "down": {}}
+
+    def fake_prescan(layer, num_experts):
+        assert num_experts == 96
+        return expected
+
+    monkeypatch.setattr(exl3, "_try_prescan_trellis_shapes", fake_prescan)
+    monkeypatch.delattr(exl3, "_vllm_exl3_mixed_k_prescan_guard_installed", raising=False)
+    install_mixed_k_prescan_guard(exl3)
+
+    layer = SimpleNamespace(expert_placement_strategy="linear")
+    assert exl3._try_prescan_trellis_shapes(layer, 96) == expected

--- a/tests/test_trellis_arenas.py
+++ b/tests/test_trellis_arenas.py
@@ -1,0 +1,164 @@
+"""Synthetic CPU tests for contiguous per-shape trellis arenas + direct fill."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import vllm_exl3.exl3 as exl3
+
+
+def _new_moe_method(moe, cfg, bits: int = 4):
+    """Construct Exl3MoEMethod without requiring a real vLLM FusedMoEMethodBase."""
+    method = object.__new__(exl3.Exl3MoEMethod)
+    method.moe = moe
+    method.quant_config = cfg
+    method.bits = int(bits)
+    method._logged = False
+    return method
+
+
+class _MoeCfg:
+    hidden_dim = 64
+    num_experts = 4
+    num_local_experts = 4
+    experts_per_token = 2
+    activation = "silu"
+    rocm_aiter_fmoe_enabled = False
+    swiglu_limit = None
+
+
+class _Layer(torch.nn.Module):
+    def __init__(self, n: int) -> None:
+        super().__init__()
+        self.moe_config = _MoeCfg()
+        self.layer_name = "layers.0.ffn.experts"
+        self.global_num_experts = n
+        self.local_num_experts = n
+        self.starting_expert_offset = 0
+
+    def _map_global_expert_id_to_local_expert_id(self, expert_id: int) -> int:
+        return int(expert_id) if 0 <= int(expert_id) < self.local_num_experts else -1
+
+
+def _stub_linear(trellis, suh, svh, mcg=None, mul1=None, **_kwargs):
+    return SimpleNamespace(
+        trellis=trellis,
+        suh=suh,
+        svh=svh,
+        mcg=True,
+        mul1=False,
+        forward=lambda *a, **k: None,
+    )
+
+
+def _make(n: int = 4):
+    method = _new_moe_method(_MoeCfg(), exl3.Exl3Config(bits=4, codebook="mcg", scope="test"), bits=4)
+    layer = _Layer(n)
+    method.create_weights(
+        layer,
+        num_experts=n,
+        hidden_size=64,
+        intermediate_size_per_partition=64,
+        params_dtype=torch.bfloat16,
+    )
+    layer.moe_tp_size = 1
+    layer.tp_rank = 0
+    return method, layer
+
+
+def _trellis(in_t, out_t, k):
+    return torch.arange(in_t * out_t * k * 16, dtype=torch.int16).reshape(
+        in_t, out_t, k * 16
+    )
+
+
+def _load_all(method, layer, ks_gate, ks_up, ks_down, *, arena: bool):
+    import os
+
+    os.environ["VLLM_EXL3_TRELLIS_ARENA"] = "1" if arena else "0"
+    os.environ["VLLM_EXL3_ARENA_PRESCAN"] = "0"
+    for eid, (kg, ku, kd) in enumerate(zip(ks_gate, ks_up, ks_down)):
+        payloads = {
+            ("w1", "trellis"): _trellis(4, 4, kg),
+            ("w3", "trellis"): _trellis(4, 4, ku),
+            ("w2", "trellis"): _trellis(4, 4, kd),
+            ("w1", "suh"): torch.ones(64, dtype=torch.float16),
+            ("w3", "suh"): torch.ones(64, dtype=torch.float16),
+            ("w2", "suh"): torch.ones(64, dtype=torch.float16),
+            ("w1", "svh"): torch.ones(64, dtype=torch.float16),
+            ("w3", "svh"): torch.ones(64, dtype=torch.float16),
+            ("w2", "svh"): torch.ones(64, dtype=torch.float16),
+            ("w1", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+            ("w3", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+            ("w2", "mcg"): torch.tensor(exl3.MCG_MARKER_SIGNED_INT32, dtype=torch.int32),
+        }
+        for (proj, kind), tensor in payloads.items():
+            if kind == "trellis":
+                param = layer.w13_trellis if proj in ("w1", "w3") else layer.w2_trellis
+            else:
+                param = (
+                    getattr(layer, f"w13_{kind}")
+                    if proj in ("w1", "w3")
+                    else getattr(layer, f"w2_{kind}")
+                )
+            assert method._load_exl3(
+                param,
+                tensor,
+                f"experts.{eid}.{proj}.{kind}",
+                shard_id=proj,
+                expert_id=eid,
+                return_success=True,
+            )
+
+
+def test_stage_pack_reduces_storage_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(exl3, "make_linear_exl3", _stub_linear)
+    ks = [3, 4, 3, 5]
+    # Legacy
+    method_l, layer_l = _make(4)
+    _load_all(method_l, layer_l, ks, ks, ks, arena=False)
+    method_l.process_weights_after_loading(layer_l)
+    stor_l = exl3._count_trellis_storages(layer_l)
+    bytes_l = exl3._trellis_nbytes(layer_l)
+
+    # Arena stage-pack
+    method_a, layer_a = _make(4)
+    _load_all(method_a, layer_a, ks, ks, ks, arena=True)
+    method_a.process_weights_after_loading(layer_a)
+    stor_a = exl3._count_trellis_storages(layer_a)
+    bytes_a = exl3._trellis_nbytes(layer_a)
+    stats = layer_a._exl3_trellis_arena_stats
+    staged_left = sum(len(m) for m in layer_a._exl3_trellis_staging.values())
+
+    assert staged_left == 0
+    assert stor_a < stor_l
+    assert bytes_a == bytes_l
+    assert stats.get("allocations_after", stor_a) < stor_l
+    assert layer_a._exl3_mixed_k is True
+    for eid, k in enumerate(ks):
+        assert torch.equal(layer_a.gate_trellis[eid].cpu(), _trellis(4, 4, k))
+
+
+def test_direct_fill_plan_temp_peak_below_final(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(exl3, "make_linear_exl3", _stub_linear)
+    monkeypatch.setenv("VLLM_EXL3_TRELLIS_ARENA", "1")
+    monkeypatch.setenv("VLLM_EXL3_ARENA_PRESCAN", "0")
+    method, layer = _make(4)
+    shapes = {
+        "gate": {i: (4, 4, k * 16) for i, k in enumerate([3, 4, 3, 5])},
+        "up": {i: (4, 4, k * 16) for i, k in enumerate([3, 4, 3, 5])},
+        "down": {i: (4, 4, k * 16) for i, k in enumerate([3, 4, 3, 5])},
+    }
+    exl3.prepare_trellis_arena_plan(layer, shapes)
+    _load_all(method, layer, [3, 4, 3, 5], [3, 4, 3, 5], [3, 4, 3, 5], arena=True)
+    method.process_weights_after_loading(layer)
+    stats = layer._exl3_trellis_arena_stats
+    assert stats.get("mode") == "direct_plan"
+    assert int(stats["temp_peak_bytes"]) < int(stats["final_bytes"]) // 2
+    assert exl3._count_trellis_storages(layer) <= 3 * 3  # <= one arena per K class / proj
+    for eid, k in enumerate([3, 4, 3, 5]):
+        assert torch.equal(layer.gate_trellis[eid].cpu(), _trellis(4, 4, k))

--- a/tools/exl3_pack_tools/README.md
+++ b/tools/exl3_pack_tools/README.md
@@ -9,10 +9,10 @@ before vLLM can load it.
 
 - `qwen_pack_scan.py` inventories every tensor in the pack by reading each
   `*.safetensors` header only (no tensor data). It reports, per MoE layer,
-  the set of K values across experts for gate/up/down (the plugin stacks a
-  layer's experts into one tensor, so it needs them uniform); per dense
-  linear (attention, dense MLP, shared expert, `lm_head`), its K; and for
-  each row-wise n-gram embedding table, its shard count, row count, K and
+  the set of K values across experts for gate/up/down (non-uniform expert K
+  is supported via ragged trellis storage + python_loop); per dense linear
+  (attention, dense MLP, shared expert, `lm_head`), its K; and for each
+  row-wise n-gram embedding table, its shard count, row count, K and
   auxiliary tensors. Writes `pack_scan.json` next to the pack.
 
   `python3 qwen_pack_scan.py <pack_dir> [--out scan.json]`
@@ -20,11 +20,11 @@ before vLLM can load it.
 - `qwen_pack_config.py` reads that scan and rewrites `config.json`'s
   `quantization_config` into the plugin's own fields: `layer_bits` (per-layer
   expert K overrides), `non_routed_exl3.layers` (a per-prefix bit map for
-  dense linears), and `ngram_embedding` (the row-wise table spec). It refuses
-  (exit 2) if any MoE layer's experts disagree on K, or if the pack's n-gram
-  tables have inconsistent geometry, since the plugin cannot represent
-  either case. The original block is kept under `native_quantization_config`
-  and `config.json` is backed up to `config.json.native` first.
+  dense linears), and `ngram_embedding` (the row-wise table spec). Non-uniform
+  expert K is allowed and noted; it still refuses (exit 2) if the pack's
+  n-gram tables have inconsistent geometry. The original block is kept under
+  `native_quantization_config` and `config.json` is backed up to
+  `config.json.native` first.
 
   `python3 qwen_pack_config.py <pack_dir> [--scan pack_scan.json] [--dry-run]`
 

--- a/tools/exl3_pack_tools/qwen_pack_config.py
+++ b/tools/exl3_pack_tools/qwen_pack_config.py
@@ -8,9 +8,9 @@ one K. This reads the header scan, checks that, and rewrites config.json's quant
 accordingly. The original block is preserved under `native_quantization_config` and
 config.json is backed up to config.json.native first.
 
-Refuses (exit 2) if any MoE layer has experts at different K, because the plugin stacks a
-layer's experts into one tensor and cannot hold mixed widths, or if the pack holds n-gram
-tables of differing geometry (the plugin takes one spec).
+Non-uniform expert K within a layer is supported (ragged per-expert trellis;
+heterogeneous layers use python_loop). Still refuses (exit 2) if the pack holds
+n-gram tables of differing geometry (the plugin takes one spec).
 
 usage: python3 qwen_pack_config.py <pack_dir> [--scan pack_scan.json] [--dry-run]
 """
@@ -39,32 +39,50 @@ def main():
         # config.json was already rewritten by this tool; start from the native block
         q = q["native_quantization_config"]
 
-    if scan["expert_k_nonuniform"]:
-        print("REFUSE: experts within a layer have different K; plugin cannot stack them:")
-        for r in scan["expert_k_nonuniform"][:10]:
-            print(f"  layer {r['layer']} {r['proj']}: {r['ks']}")
-        return 2
     if scan.get("ngram_problems"):
         print("REFUSE: n-gram table problems:")
         for p in scan["ngram_problems"]:
             print("  ", p)
         return 2
 
-    # one K per layer (gate/up/down must agree too, since the plugin uses one K per layer)
+    # Prefer a single representative K per layer for layer_bits. Heterogeneous
+    # experts (and gate/up/down disagreement) are allowed at load time via
+    # ragged trellis storage; config still needs a base bits + overrides map.
+    if scan["expert_k_nonuniform"]:
+        print(
+            "NOTE: experts within a layer have different K; plugin keeps exact "
+            "per-expert shapes and uses python_loop for those layers:"
+        )
+        for r in scan["expert_k_nonuniform"][:10]:
+            print(f"  layer {r['layer']} {r['proj']}: {r['ks']}")
+
     layer_k = {}
     disagree = []
     for layer, row in scan["expert_k_per_layer"].items():
-        ks = {row[p][0] for p in row}
-        if len(ks) != 1:
+        # Use the most common K across gate/up/down expert values as the layer
+        # representative (config metadata only; actual tensors keep exact K).
+        vals = []
+        for proj in row:
+            vals.extend(row[proj])
+        if not vals:
+            continue
+        counts = collections.Counter(vals)
+        rep = counts.most_common(1)[0][0]
+        layer_k[int(layer)] = rep
+        proj_reps = {p: collections.Counter(row[p]).most_common(1)[0][0] for p in row}
+        if len(set(proj_reps.values())) != 1:
             disagree.append((layer, row))
-        else:
-            layer_k[int(layer)] = ks.pop()
     if disagree:
-        print("REFUSE: gate/up/down experts differ in K within a layer:")
+        print(
+            "NOTE: gate/up/down K disagree within a layer (supported via "
+            "python_loop; layer_bits uses the mode K):"
+        )
         for layer, row in disagree[:10]:
             print(f"  layer {layer}: {row}")
-        return 2
 
+    if not layer_k:
+        print("REFUSE: no MoE expert K values found in scan")
+        return 2
     base = collections.Counter(layer_k.values()).most_common(1)[0][0]
     layer_bits = {str(l): k for l, k in sorted(layer_k.items()) if k != base}
 

--- a/tools/exl3_pack_tools/qwen_pack_scan.py
+++ b/tools/exl3_pack_tools/qwen_pack_scan.py
@@ -1,8 +1,9 @@
 """Inventory a turboderp-native EXL3 pack's tensors so the plugin's config can be derived.
 
-The vllm-exl3 plugin stacks a layer's experts into one [E, in/16, out/16, 16*K] tensor, so it
-needs a single K per MoE layer. exl3 packs quantized to a fractional average (3.05 bpw) assign K
-per tensor. This reads every safetensors header (no tensor data) and reports:
+The vllm-exl3 plugin keeps exact per-expert trellis shapes (uniform-K layers still
+use the fused fast path; heterogeneous packed K falls back to python_loop).
+exl3 packs quantized to a fractional average (3.05 bpw) assign K per tensor.
+This reads every safetensors header (no tensor data) and reports:
   - per MoE layer: the set of K values across experts for gate/up/down (uniform or not)
   - per dense linear (attention, dense MLP, shared expert, lm_head): K and suffixes
   - row-wise n-gram embedding tables (exllamav3 ngram format): shard count, rows, K, aux tensors
@@ -157,7 +158,10 @@ def main():
             kd[tuple(ks)] += 1
     print("expert K distribution (per layer/proj):", dict(kd))
     if nonuniform:
-        print("NONUNIFORM expert K within a layer (plugin cannot stack these):")
+        print(
+            "NONUNIFORM expert K within a layer "
+            "(supported: ragged trellis + python_loop):"
+        )
         for l, p, ks in nonuniform[:12]:
             print(f"  layer {l} {p}: {ks}")
     print("dense K by family:")


### PR DESCRIPTION
Integrates @Blackwellboy's PR #10 mixed-K implementation onto current main while preserving attribution, then adds maintainer hardening:

- exact per-expert / per-projection trellis K remains the core implementation from PR #10;
- heterogeneous layers stay on correctness-first LinearEXL3 python-loop dispatch;
- uniform-K layers retain the fused fast path;
- runtime diagnostics now explicitly mark the heterogeneous path as **not CUDA-graph qualified** and recommend eager first boot;
- prescan's current expert-placement contract is documented as linear/contiguous;
- the old partial-copy trellis diagnostic is explicitly superseded by exact-shape loading, while non-trellis mismatches continue to hard-fail;
- adds a regression test for these runtime promises.

The branch starts from GitHub's test merge for PR #10, so @Blackwellboy's original commit remains in ancestry. Full 4x Spark `/v1/models` qualification is still required before calling the TP4 path production-ready.