### PR TITLE
fix: derive fused MoE K from physical trellis geometry

### DIFF
--- a/src/vllm_exl3/__init__.py
+++ b/src/vllm_exl3/__init__.py
@@ -36,6 +36,7 @@ def register() -> None:
     from .deepseek_v41 import install_deepseek_v41_compat
     from .k78_compat import install_k78_config_compat
     from .mixed_k_guard import install_mixed_k_prescan_guard
+    from .physical_k_compat import install_physical_fused_k_compat
     from .runtime_policy import install_native_row_policy
     from .tp_geometry_compat import install_tp_geometry_compat
     from .uva_offload import install_uva_expert_validation
@@ -54,6 +55,11 @@ def register() -> None:
     # range. Disable that optimization for non-linear placement/EPLB and let the
     # authoritative vLLM loader mapping drive expert ownership instead.
     install_mixed_k_prescan_guard(exl3)
+
+    # Fused/native layers must use the K encoded by the physical trellis rather
+    # than a possibly stale config/base K. This also rejects accidental fused
+    # construction if heterogeneous physical K somehow reaches that path.
+    install_physical_fused_k_compat(exl3)
 
     # Install model-family compatibility before runtime policy wrappers inspect
     # the quantization config. vLLM still owns the DeepSeek V4.1 architecture.
@@ -115,6 +121,10 @@ def runtime_diagnostics():
         "tensor_level_mixed_k_within_layer": True,
         "heterogeneous_dispatch": "python_loop",
         "uniform_k_dispatch": "fused_when_available",
+        "fused_k_source": "physical_trellis_geometry",
+        "physical_fused_k_guard_installed": bool(
+            getattr(exl3, "_vllm_exl3_physical_fused_k_compat_installed", False)
+        ),
         "cudagraph_qualified": False,
         "recommended_first_boot": "eager",
         "arena_prescan_placement_contract": "linear_contiguous_global_expert_ids",
@@ -132,7 +142,8 @@ def runtime_diagnostics():
             "path remains K2-K4. Routed experts store exact per-expert trellis "
             "shapes (including intra-expert w1/w2/w3 K disagreement). "
             "Heterogeneous packed K within a layer forces the LinearEXL3 "
-            "python_loop; uniform-K layers still use the fused fast path. "
+            "python_loop; uniform-K layers still use the fused fast path using "
+            "the K encoded by the loaded trellis, not a config default. "
             "The heterogeneous path is correctness-first and should remain eager "
             "until CUDA-graph qualification is completed."
         ),

--- a/src/vllm_exl3/physical_k_compat.py
+++ b/src/vllm_exl3/physical_k_compat.py
@@ -1,0 +1,74 @@
+"""Derive fused routed-expert K from the loaded trellis, not config defaults.
+
+Mixed-K packs are self-describing: ``LinearEXL3.K`` comes from the physical
+``trellis.shape[-1] // 16``. A layer may be physically uniform at K5/K7 while
+its config/base ``bits`` is different. Fused kernels must receive the physical
+uniform K or they will interpret the trellis with the wrong width.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _physical_k_values(inners: list[dict[str, Any]]) -> set[int]:
+    values: set[int] = set()
+    for pack in inners:
+        for projection in ("gate", "up", "down"):
+            linear = pack[projection]
+            k = getattr(linear, "K", None)
+            if k is None:
+                trellis = getattr(linear, "trellis", None)
+                if trellis is None or getattr(trellis, "ndim", 0) != 3:
+                    raise RuntimeError(
+                        f"EXL3 fused state cannot determine physical K for {projection}"
+                    )
+                words = int(trellis.shape[-1])
+                if words <= 0 or words % 16:
+                    raise RuntimeError(
+                        f"EXL3 fused state invalid trellis width {words} for {projection}"
+                    )
+                k = words // 16
+            values.add(int(k))
+    return values
+
+
+def install_physical_fused_k_compat(exl3_module: Any) -> None:
+    original = getattr(exl3_module, "build_exl3_fused_state", None)
+    if not callable(original):
+        return
+    if bool(getattr(original, "_vllm_exl3_physical_k_wrapped", False)):
+        return
+
+    def wrapped(layer: Any, inners: list[dict[str, Any]]) -> None:
+        physical = _physical_k_values(inners)
+        if len(physical) != 1:
+            raise RuntimeError(
+                "EXL3 fused MoE requires one physical K across gate/up/down and "
+                f"all local experts; loaded K values={sorted(physical)}"
+            )
+        physical_k = next(iter(physical))
+        if not 1 <= physical_k <= 8:
+            raise RuntimeError(
+                f"EXL3 fused MoE physical K={physical_k} is outside K1-K8"
+            )
+
+        original(layer, inners)
+        configured = int(getattr(layer, "_exl3_bits", physical_k))
+        layer._exl3_k = physical_k
+        layer._exl3_physical_fused_k = physical_k
+        layer._exl3_configured_k = configured
+
+        if configured != physical_k:
+            logger = getattr(exl3_module, "logger", None)
+            if logger is not None:
+                getattr(logger, "info_once", logger.info)(
+                    "EXL3 fused layer physical K overrides config/base K: "
+                    "physical=%s configured=%s",
+                    physical_k,
+                    configured,
+                )
+
+    wrapped._vllm_exl3_physical_k_wrapped = True
+    wrapped._vllm_exl3_original = original
+    exl3_module.build_exl3_fused_state = wrapped
+    exl3_module._vllm_exl3_physical_fused_k_compat_installed = True

--- a/tests/test_physical_k_compat.py
+++ b/tests/test_physical_k_compat.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_exl3.physical_k_compat import install_physical_fused_k_compat
+
+
+class _Logger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def info_once(self, *args, **kwargs):
+        pass
+
+
+def _pack(gate: int, up: int, down: int):
+    return {
+        "gate": SimpleNamespace(K=gate),
+        "up": SimpleNamespace(K=up),
+        "down": SimpleNamespace(K=down),
+    }
+
+
+def test_uniform_physical_k_overrides_config_k() -> None:
+    def original(layer, inners):
+        # Reproduce the pre-fix behavior of the core helper.
+        layer._exl3_k = int(layer._exl3_bits)
+
+    module = SimpleNamespace(build_exl3_fused_state=original, logger=_Logger())
+    install_physical_fused_k_compat(module)
+
+    layer = SimpleNamespace(_exl3_bits=4)
+    module.build_exl3_fused_state(layer, [_pack(7, 7, 7), _pack(7, 7, 7)])
+
+    assert layer._exl3_k == 7
+    assert layer._exl3_physical_fused_k == 7
+    assert layer._exl3_configured_k == 4
+
+
+def test_uniform_physical_k_matching_config_stays_same() -> None:
+    def original(layer, inners):
+        layer._exl3_k = int(layer._exl3_bits)
+
+    module = SimpleNamespace(build_exl3_fused_state=original, logger=_Logger())
+    install_physical_fused_k_compat(module)
+
+    layer = SimpleNamespace(_exl3_bits=4)
+    module.build_exl3_fused_state(layer, [_pack(4, 4, 4)])
+
+    assert layer._exl3_k == 4
+    assert layer._exl3_physical_fused_k == 4
+
+
+def test_heterogeneous_physical_k_cannot_build_fused_state() -> None:
+    calls = []
+
+    def original(layer, inners):
+        calls.append(True)
+
+    module = SimpleNamespace(build_exl3_fused_state=original, logger=_Logger())
+    install_physical_fused_k_compat(module)
+
+    with pytest.raises(RuntimeError, match="requires one physical K"):
+        module.build_exl3_fused_state(
+            SimpleNamespace(_exl3_bits=4), [_pack(3, 4, 3)]
+        )
+    assert calls == []
+
+
+def test_runtime_register_installs_physical_k_guard() -> None:
+    import vllm_exl3
+
+    vllm_exl3.register()
+    mixed = vllm_exl3.runtime_diagnostics()["mixed_k"]
+    assert mixed["physical_fused_k_guard_installed"] is True
+    assert mixed["fused_k_source"] == "physical_trellis_geometry"


### PR DESCRIPTION
Follow-up correctness hardening after @Blackwellboy's merged mixed-K PR #10.

A physically uniform layer can still have K different from the config/base `bits`. The fused path previously populated `_exl3_k` from config metadata, which could make e.g. a physical K7 layer launch as K4.

This change wraps fused-state construction so it:
- derives K from each loaded `LinearEXL3.K` / trellis geometry;
- requires one physical K across all gate/up/down projections before fused execution;
- writes the physical K into `_exl3_k` even when config/base K differs;
- records the configured and physical K for diagnostics;
- adds regression tests for physical K7 over config K4 and heterogeneous rejection.

This is a maintainer follow-up; @Blackwellboy's original mixed-K commit remains in main ancestry unchanged.